### PR TITLE
Remove scale_factor from XEE encoding

### DIFF
--- a/city_metrix/layers/layer.py
+++ b/city_metrix/layers/layer.py
@@ -233,5 +233,10 @@ def get_image_collection(
 
     # get in rioxarray format
     data = data.squeeze("time").transpose("Y", "X").rename({'X': 'x', 'Y': 'y'})
+
+    # remove scale_factor used for NetCDF, this confuses rioxarray GeoTiffs
+    for data_var in list(data.data_vars.values()):
+        del data_var.encoding["scale_factor"]
+
     return data
 


### PR DESCRIPTION
## What changes were proposed in this PR?

Xee seems to set a 'scale_factor' in an encoding dictionary on your xarray. As far as I can tell, this is used by NetCDF for writing your data efficiently: https://docs.xarray.dev/en/stable/user-guide/io.html#reading-encoded-data

This value is just whatever you pass as the scale to GEE. This seems to confuse rioxarray, which then believes you want to use a GDAL option that also scales your data down, but doesn't seem to rescale it automatically when you read it. This makes it so all your values will be scaled down based on your pixel size.

Since I don't think we want to use this feature, I just made the Xee read function to remove this value from the encoding.

## How was this patch tested?

Tested with a notebook and in tests.

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
