### PR TITLE
Update dev_ci_cd.yml

### DIFF
--- a/.github/workflows/dev_ci_cd.yml
+++ b/.github/workflows/dev_ci_cd.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Linux dependencies


### PR DESCRIPTION
Using the latest versions to address https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/