### PR TITLE
Cdb 83 run metric by using pre calculated layers

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2025/04/9
+1. Merged some Layers and Metrics functions
+2. Increased granularity for controling whether individual tests are run by converting the old EXECUTE_IGNORED_TESTS boolean values into enums.
+
 ## 2025/04/7
 1. Created a Metric base class with get_data() and two write functions
 2. Converted each existing Metric function into a Metric class with get_data() function

--- a/city_metrix/constants.py
+++ b/city_metrix/constants.py
@@ -4,6 +4,7 @@ WGS_EPSG_CODE = 4326
 GTIFF_FILE_EXTENSION = 'tif'
 GEOJSON_FILE_EXTENSION = 'geojson'
 NETCDF_FILE_EXTENSION = 'nc'
+CSV_FILE_EXTENSION = 'csv'
 
 # TODO replace with production value
 cif_production_aws_bucket_uri = 's3://cities-dev-sandbox' # 's3://wri-cities-data-api'

--- a/city_metrix/layers/acag_pm2p5.py
+++ b/city_metrix/layers/acag_pm2p5.py
@@ -1,10 +1,7 @@
-from dask.diagnostics import ProgressBar
-import xarray as xr
-import xee
 import ee
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/albedo.py
+++ b/city_metrix/layers/albedo.py
@@ -1,10 +1,8 @@
 import ee
-import xarray
-from dask.diagnostics import ProgressBar
 
 from .layer import (Layer, get_image_collection, set_resampling_for_continuous_raster,
                     validate_raster_resampling_method)
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/alos_dsm.py
+++ b/city_metrix/layers/alos_dsm.py
@@ -1,9 +1,7 @@
 import ee
-import xee
-import xarray as xr
 
 from .layer import Layer, get_image_collection, set_resampling_for_continuous_raster, validate_raster_resampling_method
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/aqueduct_flood.py
+++ b/city_metrix/layers/aqueduct_flood.py
@@ -1,10 +1,7 @@
-from dask.diagnostics import ProgressBar
-import xarray as xr
-import xee
 import ee
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/average_net_building_height.py
+++ b/city_metrix/layers/average_net_building_height.py
@@ -1,10 +1,7 @@
-from dask.diagnostics import ProgressBar
-import xarray as xr
-import xee
 import ee
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/built_up_height.py
+++ b/city_metrix/layers/built_up_height.py
@@ -1,10 +1,7 @@
-from dask.diagnostics import ProgressBar
-import xarray as xr
-import xee
 import ee
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/cams.py
+++ b/city_metrix/layers/cams.py
@@ -4,7 +4,7 @@ import xarray as xr
 import glob
 
 from .layer import Layer
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import NETCDF_FILE_EXTENSION
 

--- a/city_metrix/layers/era_5_hottest_day.py
+++ b/city_metrix/layers/era_5_hottest_day.py
@@ -10,7 +10,7 @@ import glob
 
 from city_metrix.constants import WGS_CRS, NETCDF_FILE_EXTENSION
 from .layer import Layer
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 
 

--- a/city_metrix/layers/esa_world_cover.py
+++ b/city_metrix/layers/esa_world_cover.py
@@ -1,10 +1,8 @@
-from dask.diagnostics import ProgressBar
 from enum import Enum
-import xarray as xr
 import ee
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/glad_lulc.py
+++ b/city_metrix/layers/glad_lulc.py
@@ -2,7 +2,7 @@ import xarray as xr
 import ee
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/height_above_nearest_drainage.py
+++ b/city_metrix/layers/height_above_nearest_drainage.py
@@ -1,9 +1,7 @@
-from dask.diagnostics import ProgressBar
-import xarray as xr
 import ee
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/high_land_surface_temperature.py
+++ b/city_metrix/layers/high_land_surface_temperature.py
@@ -1,11 +1,9 @@
-from .landsat_collection_2 import LandsatCollection2
 from .land_surface_temperature import LandSurfaceTemperature
 from .layer import Layer
-from shapely.geometry import box
 import datetime
 import ee
 
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/high_slope.py
+++ b/city_metrix/layers/high_slope.py
@@ -1,9 +1,8 @@
-import ee
 from xrspatial import slope
 
 from .layer import Layer, validate_raster_resampling_method
 from .nasa_dem import NasaDEM
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/impervious_surface.py
+++ b/city_metrix/layers/impervious_surface.py
@@ -1,10 +1,7 @@
-from dask.diagnostics import ProgressBar
-import xarray as xr
-import xee
 import ee
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/land_surface_temperature.py
+++ b/city_metrix/layers/land_surface_temperature.py
@@ -1,10 +1,7 @@
-from .landsat_collection_2 import LandsatCollection2
 from .layer import Layer, get_image_collection
-from dask.diagnostics import ProgressBar
 import ee
-import xarray
 
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/landsat_collection_2.py
+++ b/city_metrix/layers/landsat_collection_2.py
@@ -2,7 +2,7 @@ import odc.stac
 import pystac_client
 
 from .layer import Layer
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/layer.py
+++ b/city_metrix/layers/layer.py
@@ -1,14 +1,10 @@
 import os
 from abc import abstractmethod
 from typing import Union
-from uuid import uuid4
 
-import xee
 # This osgeo import is essential for proper functioning. Do not remove.
-from osgeo import gdal
 
 import ee
-import boto3
 from dask.diagnostics import ProgressBar
 from ee import ImageCollection
 from geocube.api.core import make_geocube
@@ -20,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 from city_metrix.constants import WGS_CRS, GTIFF_FILE_EXTENSION, GEOJSON_FILE_EXTENSION, NETCDF_FILE_EXTENSION
-from city_metrix.layers.layer_dao import write_tile_grid, write_geodataarray, write_geodataframe, write_dataarray, \
+from city_metrix.metrix_dao import write_tile_grid, write_geotiff, write_geojson, write_netcdf, \
     write_dataset
 from city_metrix.layers.layer_tools import standardize_y_dimension_direction
 from city_metrix.layers.layer_geometry import GeoExtent, create_fishnet_grid, reproject_units
@@ -148,14 +144,14 @@ def _write_layer(data, uri, file_format):
         if standardized_array.values.dtype.name == 'bool':
             standardized_array = standardized_array.astype(np.uint8)
 
-        write_geodataarray(standardized_array, uri)
+        write_geotiff(standardized_array, uri)
     elif isinstance(data, xr.Dataset) and file_format == GTIFF_FILE_EXTENSION:
         raise NotImplementedError(f"Write function does not support format: {type(data).__name__}")
         write_dataset(data, uri)
     elif isinstance(data, xr.DataArray) and file_format == NETCDF_FILE_EXTENSION:
-        write_dataarray(data, uri)
+        write_netcdf(data, uri)
     elif isinstance(data, gpd.GeoDataFrame) and file_format == GEOJSON_FILE_EXTENSION:
-        write_geodataframe(data, uri)
+        write_geojson(data, uri)
     else:
         raise NotImplementedError(f"Write function does not support format: {type(data).__name__}")
 

--- a/city_metrix/layers/layer_geometry.py
+++ b/city_metrix/layers/layer_geometry.py
@@ -1,21 +1,17 @@
 import math
-import os
-from pathlib import Path
 
 import ee
-import rioxarray
 import shapely
 import utm
 import shapely.geometry as geometry
 import geopandas as gpd
 
 from typing import Union
-from pyproj import CRS
 from shapely.geometry import point
 
 from city_metrix.constants import WGS_CRS
-from city_metrix.layers.layer_dao import get_city, get_city_boundary, get_s3_client
-from city_metrix.layers.layer_tools import get_projection_name, get_haversine_distance, build_cache_layer_names
+from city_metrix.metrix_dao import get_city, get_city_boundary
+from city_metrix.layers.layer_tools import get_projection_name, get_haversine_distance
 
 MAX_SIDE_LENGTH_METERS = 50000 # This values should cover most situations
 MAX_SIDE_LENGTH_DEGREES = 0.5 # Given that for latitude, 50000m * (1deg/111000m)

--- a/city_metrix/layers/nasa_dem.py
+++ b/city_metrix/layers/nasa_dem.py
@@ -1,9 +1,7 @@
 import ee
-import xee
-import xarray as xr
 
 from .layer import Layer, get_image_collection, set_resampling_for_continuous_raster, validate_raster_resampling_method
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/natural_areas.py
+++ b/city_metrix/layers/natural_areas.py
@@ -1,9 +1,8 @@
-import xarray as xr
 from xrspatial.classify import reclassify
 
 from .layer import Layer
 from .esa_world_cover import EsaWorldCover, EsaWorldCoverClass
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/ndvi_sentinel2_gee.py
+++ b/city_metrix/layers/ndvi_sentinel2_gee.py
@@ -1,7 +1,7 @@
 import ee
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/open_buildings.py
+++ b/city_metrix/layers/open_buildings.py
@@ -5,7 +5,7 @@ import geopandas as gpd
 from shapely.geometry import Polygon, MultiPolygon
 
 from .layer import Layer, WGS_CRS
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GEOJSON_FILE_EXTENSION
 

--- a/city_metrix/layers/open_street_map.py
+++ b/city_metrix/layers/open_street_map.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from city_metrix.constants import WGS_CRS, GEOJSON_FILE_EXTENSION
 from .layer import Layer
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 
 class OpenStreetMapClass(Enum):

--- a/city_metrix/layers/overture_buildings.py
+++ b/city_metrix/layers/overture_buildings.py
@@ -3,7 +3,7 @@ import subprocess
 from io import StringIO
 
 from .layer import Layer
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GEOJSON_FILE_EXTENSION
 

--- a/city_metrix/layers/pop_weighted_pm2p5.py
+++ b/city_metrix/layers/pop_weighted_pm2p5.py
@@ -1,13 +1,7 @@
-from dask.diagnostics import ProgressBar
-import xarray as xr
-import xee
-import ee
-import numpy as np
-
-from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from .layer import Layer
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
-from .world_pop import WorldPop, WorldPopClass
+from .world_pop import WorldPop
 from .acag_pm2p5 import AcagPM2p5
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/protected_areas.py
+++ b/city_metrix/layers/protected_areas.py
@@ -2,8 +2,8 @@ import ee
 import geopandas as gpd
 import geemap
 
-from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from .layer import Layer
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GEOJSON_FILE_EXTENSION
 

--- a/city_metrix/layers/riparian_areas.py
+++ b/city_metrix/layers/riparian_areas.py
@@ -5,7 +5,7 @@ from scipy.ndimage import distance_transform_edt
 
 from .layer import Layer, get_image_collection
 from .height_above_nearest_drainage import HeightAboveNearestDrainage
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/sentinel_2_level_2.py
+++ b/city_metrix/layers/sentinel_2_level_2.py
@@ -1,6 +1,6 @@
 import odc.stac
 import pystac_client
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from .layer import Layer
 from ..constants import GTIFF_FILE_EXTENSION

--- a/city_metrix/layers/smart_surface_lulc.py
+++ b/city_metrix/layers/smart_surface_lulc.py
@@ -1,16 +1,14 @@
 import xarray as xr
 import numpy as np
 import pandas as pd
-import geopandas as gpd
 from shapely.geometry import CAP_STYLE, JOIN_STYLE
-from shapely.geometry import box
 from exactextract import exact_extract
 from geocube.api.core import make_geocube
 import warnings
 from rasterio.enums import Resampling
 from xrspatial.classify import reclassify
 
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/tree_canopy_height.py
+++ b/city_metrix/layers/tree_canopy_height.py
@@ -1,10 +1,7 @@
-from dask.diagnostics import ProgressBar
-import xarray as xr
-import xee
 import ee
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/tree_cover.py
+++ b/city_metrix/layers/tree_cover.py
@@ -1,11 +1,8 @@
 from .layer import Layer, get_image_collection
 
-from dask.diagnostics import ProgressBar
-import xarray as xr
-import xee
 import ee
 
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/urban_extents.py
+++ b/city_metrix/layers/urban_extents.py
@@ -1,10 +1,9 @@
-from dask.diagnostics import ProgressBar
 import ee
 import geemap
 import geopandas as gpd
 
 from .layer import Layer
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GEOJSON_FILE_EXTENSION
 

--- a/city_metrix/layers/urban_land_use.py
+++ b/city_metrix/layers/urban_land_use.py
@@ -1,11 +1,8 @@
-from dask.diagnostics import ProgressBar
-import xarray as xr
-import xee
 import ee
 import numpy as np
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/vegetation_water_map.py
+++ b/city_metrix/layers/vegetation_water_map.py
@@ -2,7 +2,7 @@ import ee
 
 from .layer import Layer, get_image_collection
 from .albedo import Albedo
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/layers/world_pop.py
+++ b/city_metrix/layers/world_pop.py
@@ -1,11 +1,8 @@
-from dask.diagnostics import ProgressBar
-import xarray as xr
-import xee
 import ee
 from enum import Enum
 
 from .layer import Layer, get_image_collection
-from .layer_dao import retrieve_cached_city_data
+from city_metrix.metrix_dao import retrieve_cached_city_data
 from .layer_geometry import GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 

--- a/city_metrix/metrics/metric.py
+++ b/city_metrix/metrics/metric.py
@@ -7,15 +7,17 @@ import pandas as pd
 from geopandas import GeoDataFrame
 from pandas import Series, DataFrame
 
+from city_metrix.metrix_dao import write_geojson, write_csv
+
 
 class Metric():
-    def __init__(self, aggregate=None):
-        self.aggregate = aggregate
-        if aggregate is None:
+    def __init__(self, layer=None):
+        self.aggregate = layer
+        if layer is None:
             self.aggregate = self
 
     @abstractmethod
-    def get_data(self, zones: GeoDataFrame, spatial_resolution:int) -> gpd.GeoSeries:
+    def get_data(self, zones: GeoDataFrame, spatial_resolution:int) -> pd.Series:
         """
         Construct polygonal dataset using baser layers
         :return: A rioxarray-format GeoPandas DataFrame
@@ -38,7 +40,7 @@ class Metric():
 
         if isinstance(indicator, (pd.Series, pd.DataFrame)):
             gdf = pd.concat([zones, indicator], axis=1)
-            gdf.to_file(output_path, driver="GeoJSON")
+            write_geojson(gdf, output_path)
         else:
             raise NotImplementedError("Can only write Series or Dataframe Indicator data")
 
@@ -57,7 +59,7 @@ class Metric():
             indicator.name = 'indicator'
 
         if isinstance(indicator, (pd.Series, pd.DataFrame)):
-            indicator.to_csv(output_path, header=True, index=True, index_label='index')
+            write_csv(indicator, output_path)
         else:
             raise NotImplementedError("Can only write Series or Dataframe Indicator data")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from city_metrix.layers import Layer
 from city_metrix.constants import WGS_EPSG_CODE
 from city_metrix.layers.layer import create_fishnet_grid, WGS_CRS
@@ -7,12 +9,15 @@ from city_metrix.layers.layer_geometry import GeoExtent
 from tests.resources.bbox_constants import BBOX_USA_OR_PORTLAND, BBOX_NLD_AMSTERDAM, BBOX_IDN_JAKARTA, \
     BBOX_IDN_JAKARTA_LARGE
 
-# EXECUTE_IGNORED_TESTS is the master control for whether to execute tests decorated with
-# pytest.mark.skipif. These tests are temporarily ignored due to some unresolved issue.
-# Setting EXECUTE_IGNORED_TESTS to True turns on code execution. This should be done for local testing.
-# The value must be set to False when pushing to GitHub since the ignored tests would otherwise fail
+class TestRunLevel(Enum):
+    RUN_NONE = 0
+    RUN_FAST_ONLY = 1
+    RUN_ALL = 2
+
+# TEST_RUN_LEVEL is the master control for when  to execute tests decorated with
+# pytest.mark.skipif based on the TestRunLevel enum class.
 # in GitHub Actions.
-EXECUTE_IGNORED_TESTS = False
+TEST_RUN_LEVEL = TestRunLevel.RUN_NONE
 
 def create_fishnet_grid_for_testing(coords, tile_side_length):
     min_x, min_y, max_x, max_y = coords

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -1,4 +1,6 @@
 import tempfile
+from enum import Enum
+
 import pytest
 import os
 import shutil
@@ -8,10 +10,14 @@ from tests.resources.bbox_constants import BBOX_BRA_LAURO_DE_FREITAS_1, BBOX_NLD
     BBOX_NLD_AMSTERDAM_LARGE, BBOX_USA_OR_PORTLAND, BBOX_USA_OR_PORTLAND_1
 from tests.tools.general_tools import create_target_folder, is_valid_path
 
-# EXECUTE_IGNORED_TESTS is the master control for whether the writes and tests are executed
-# Setting EXECUTE_IGNORED_TESTS to True turns on code execution.
-# Values should normally be set to False in order to avoid unnecessary execution.
-EXECUTE_IGNORED_TESTS = False
+class DumpRunLevel(Enum):
+    RUN_NONE = 0
+    RUN_FAST_ONLY = 1
+    RUN_ALL = 2
+
+# DUMP_RUN_LEVEL is the master control for when  to execute tests decorated with
+# pytest.mark.skipif based on the DumpRunLevel enum class.
+DUMP_RUN_LEVEL = DumpRunLevel.RUN_NONE
 
 # Define a WGS bbox or otherwise a utm bbox
 USE_WGS_BBOX = True
@@ -36,7 +42,7 @@ CUSTOM_DUMP_DIRECTORY = None
 
 def pytest_configure(config):
 
-    if EXECUTE_IGNORED_TESTS is True:
+    if DUMP_RUN_LEVEL is True:
         source_folder = os.path.dirname(__file__)
         target_folder = get_target_folder_path()
         create_target_folder(target_folder, False)

--- a/tests/resources/layer_dumps/test_write_all_layers.py
+++ b/tests/resources/layer_dumps/test_write_all_layers.py
@@ -55,12 +55,12 @@ def test_write_built_up_height(target_folder, sample_aoi):
     BuiltUpHeight().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
-def test_write_cams(target_folder, sample_aoi):
-    file_path = prep_output_path(target_folder, 'cams.nc')
-    bbox = get_test_bbox(sample_aoi.geo_extent)
-    Cams().write(bbox, file_path, tile_side_length=None)
-    assert verify_file_is_populated(file_path)
+# @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+# def test_write_cams(target_folder, sample_aoi):
+#     file_path = prep_output_path(target_folder, 'cams.nc')
+#     bbox = get_test_bbox(sample_aoi.geo_extent)
+#     Cams().write(bbox, file_path, tile_side_length=None)
+#     assert verify_file_is_populated(file_path)
 
 @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
 def test_write_era_5_hottest_day(target_folder, sample_aoi):

--- a/tests/resources/layer_dumps/test_write_all_layers.py
+++ b/tests/resources/layer_dumps/test_write_all_layers.py
@@ -3,11 +3,11 @@
 import pytest
 
 from city_metrix.layers import *
-from tests.resources.conftest import EXECUTE_IGNORED_TESTS, prep_output_path, verify_file_is_populated
+from tests.resources.conftest import DUMP_RUN_LEVEL, prep_output_path, verify_file_is_populated, DumpRunLevel
 from .tools import get_test_resolution, get_test_bbox
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_acag_pm2p5(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'acag_pm2p5.tif')
     target_resolution = get_test_resolution(AcagPM2p5())
@@ -15,7 +15,7 @@ def test_write_acag_pm2p5(target_folder, sample_aoi):
     AcagPM2p5().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_albedo(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'albedo.tif')
     target_resolution = get_test_resolution(Albedo())
@@ -23,7 +23,7 @@ def test_write_albedo(target_folder, sample_aoi):
     Albedo().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_alos_dsm(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'alos_dsm.tif')
     target_resolution = get_test_resolution(AlosDSM())
@@ -31,7 +31,7 @@ def test_write_alos_dsm(target_folder, sample_aoi):
     AlosDSM().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_aqueduct_flood(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'aqueduct_flood.tif')
     target_resolution = get_test_resolution(AqueductFlood())
@@ -39,7 +39,7 @@ def test_write_aqueduct_flood(target_folder, sample_aoi):
     AqueductFlood().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_average_net_building_height(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'average_net_building_height.tif')
     target_resolution = get_test_resolution(AverageNetBuildingHeight())
@@ -47,7 +47,7 @@ def test_write_average_net_building_height(target_folder, sample_aoi):
     AverageNetBuildingHeight().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_built_up_height(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'built_up_height.tif')
     target_resolution = get_test_resolution(BuiltUpHeight())
@@ -55,21 +55,21 @@ def test_write_built_up_height(target_folder, sample_aoi):
     BuiltUpHeight().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-# @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
-# def test_write_cams(target_folder, sample_aoi):
-#     file_path = prep_output_path(target_folder, 'cams.nc')
-#     bbox = get_test_bbox(sample_aoi.geo_extent)
-#     Cams().write(bbox, file_path, tile_side_length=None)
-#     assert verify_file_is_populated(file_path)
+@pytest.mark.skipif(DUMP_RUN_LEVEL != DumpRunLevel.RUN_ALL, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
+def test_write_cams(target_folder, sample_aoi):
+    file_path = prep_output_path(target_folder, 'cams.nc')
+    bbox = get_test_bbox(sample_aoi.geo_extent)
+    Cams().write(bbox, file_path, tile_side_length=None)
+    assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL != DumpRunLevel.RUN_ALL, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_era_5_hottest_day(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'era_5_hottest_day.nc')
     bbox = get_test_bbox(sample_aoi.geo_extent)
     Era5HottestDay().write(bbox, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_esa_world_cover(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'esa_world_cover.tif')
     target_resolution = get_test_resolution(EsaWorldCover())
@@ -77,7 +77,7 @@ def test_write_esa_world_cover(target_folder, sample_aoi):
     EsaWorldCover().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_glad_land_cover(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'glad_lulc.tif')
     target_resolution = get_test_resolution(LandCoverGlad())
@@ -85,7 +85,7 @@ def test_write_glad_land_cover(target_folder, sample_aoi):
     LandCoverGlad().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_glad_land_cover_simplified(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'glad_land_cover_simplified.tif')
     target_resolution = get_test_resolution(LandCoverGlad())
@@ -94,7 +94,7 @@ def test_write_glad_land_cover_simplified(target_folder, sample_aoi):
     assert verify_file_is_populated(file_path)
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_glad_land_cover_habitat(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'glad_land_cover_habitat.tif')
     target_resolution = get_test_resolution(LandCoverGlad())
@@ -102,7 +102,7 @@ def test_write_glad_land_cover_habitat(target_folder, sample_aoi):
     LandCoverHabitatGlad().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_glad_land_cover_habitat_change(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'glad_land_cover_habitat_change.tif')
     target_resolution = get_test_resolution(LandCoverGlad())
@@ -110,7 +110,7 @@ def test_write_glad_land_cover_habitat_change(target_folder, sample_aoi):
     LandCoverHabitatChangeGlad().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_height_above_nearest_drainage(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'height_above_nearest_drainage.tif')
     target_resolution = get_test_resolution(HeightAboveNearestDrainage())
@@ -118,7 +118,7 @@ def test_write_height_above_nearest_drainage(target_folder, sample_aoi):
     HeightAboveNearestDrainage().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_high_land_surface_temperature(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'high_land_surface_temperature.tif')
     target_resolution = get_test_resolution(HighLandSurfaceTemperature())
@@ -126,7 +126,7 @@ def test_write_high_land_surface_temperature(target_folder, sample_aoi):
     HighLandSurfaceTemperature().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_high_slope(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'high_slope.tif')
     target_resolution = get_test_resolution(HighSlope())
@@ -134,7 +134,7 @@ def test_write_high_slope(target_folder, sample_aoi):
     HighSlope().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_impervious_surface(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'impervious_surface.tif')
     target_resolution = get_test_resolution(ImperviousSurface())
@@ -142,7 +142,7 @@ def test_write_impervious_surface(target_folder, sample_aoi):
     ImperviousSurface().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_land_surface_temperature(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'land_surface_temperature.tif')
     target_resolution = get_test_resolution(LandSurfaceTemperature())
@@ -151,7 +151,7 @@ def test_write_land_surface_temperature(target_folder, sample_aoi):
     assert verify_file_is_populated(file_path)
 
 # # TODO Determine how to write out file from temporal dataset
-# @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+# @pytest.mark.skipif(TEST_RUN_LEVEL != TestRunLevel.RUN_ALL, reason=f"Skipping since TEST_RUN_LEVEL set to {TEST_RUN_LEVEL}")
 # def test_write_landsat_collection_2(target_folder, sample_aoi):
 #     file_path = prep_output_path(target_folder, 'landsat_collection2.tif')
 #     bbox = get_test_bbox(sample_aoi.geo_extent)
@@ -159,7 +159,7 @@ def test_write_land_surface_temperature(target_folder, sample_aoi):
 #     LandsatCollection2(bands).write(bbox, file_path, tile_side_length=None)
 #     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_nasa_dem(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'nasa_dem.tif')
     target_resolution = get_test_resolution(NasaDEM())
@@ -167,7 +167,7 @@ def test_write_nasa_dem(target_folder, sample_aoi):
     NasaDEM().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_natural_areas(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'natural_areas.tif')
     target_resolution = get_test_resolution(NaturalAreas())
@@ -175,7 +175,7 @@ def test_write_natural_areas(target_folder, sample_aoi):
     NaturalAreas().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_ndvi_sentinel2_gee(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'ndvi_sentinel2_gee.tif')
     target_resolution = get_test_resolution(NdviSentinel2())
@@ -183,14 +183,14 @@ def test_write_ndvi_sentinel2_gee(target_folder, sample_aoi):
     NdviSentinel2(year=2023).write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_openbuildings(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'open_buildings.geojson')
     bbox = get_test_bbox(sample_aoi.geo_extent)
     OpenBuildings(sample_aoi.country).write(bbox, file_path, tile_side_length=None)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_open_street_map_roads(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'open_street_map_roads.geojson')
     bbox = get_test_bbox(sample_aoi.geo_extent)
@@ -198,28 +198,28 @@ def test_write_open_street_map_roads(target_folder, sample_aoi):
     OpenStreetMap(road_features).write(bbox, file_path, tile_side_length=None)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_overture_buildings(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'overture_buildings.geojson')
     bbox = get_test_bbox(sample_aoi.geo_extent)
     OvertureBuildings().write(bbox, file_path, tile_side_length=None)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_pop_weighted_pm2p5(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'pop_weighted_pm2p5.tif')
     target_resolution = get_test_resolution(PopWeightedPM2p5())
     bbox = get_test_bbox(sample_aoi.geo_extent)
     PopWeightedPM2p5().write(bbox, file_path, spatial_resolution=target_resolution)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_protected_areas(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'protected_areas.geojson')
     bbox = get_test_bbox(sample_aoi.geo_extent)
     ProtectedAreas().write(bbox, file_path, tile_side_length=None)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_riparian_areas(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'riparian_areas.tif')
     target_resolution = get_test_resolution(RiparianAreas())
@@ -228,7 +228,7 @@ def test_write_riparian_areas(target_folder, sample_aoi):
     assert verify_file_is_populated(file_path)
 
 # # TODO Determine how to write out file from temporal dataset
-# @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+# @pytest.mark.skipif(TEST_RUN_LEVEL != TestRunLevel.RUN_ALL, reason=f"Skipping since TEST_RUN_LEVEL set to {TEST_RUN_LEVEL}")
 # def test_write_sentinel_2_level2(target_folder, sample_aoi):
 #     file_path = prep_output_path(target_folder, 'sentinel_2_level2.tif')
 #     sentinel_2_bands = ["green"]
@@ -236,7 +236,7 @@ def test_write_riparian_areas(target_folder, sample_aoi):
 #     Sentinel2Level2(sentinel_2_bands).write(bbox, file_path, tile_side_length=None)
 #     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_smart_surface_lulc(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'smart_surface_lulc.tif')
     target_resolution = get_test_resolution(SmartSurfaceLULC())
@@ -244,7 +244,7 @@ def test_write_smart_surface_lulc(target_folder, sample_aoi):
     SmartSurfaceLULC().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_tree_canopy_height(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'tree_canopy_height.tif')
     target_resolution = get_test_resolution(TreeCanopyHeight())
@@ -252,7 +252,7 @@ def test_write_tree_canopy_height(target_folder, sample_aoi):
     TreeCanopyHeight().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_tree_cover(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'tree_cover.tif')
     target_resolution = get_test_resolution(TreeCover())
@@ -260,14 +260,14 @@ def test_write_tree_cover(target_folder, sample_aoi):
     TreeCover().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_urban_extents(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'urban_extents.geojson')
     bbox = get_test_bbox(sample_aoi.geo_extent)
     UrbanExtents().write(bbox, file_path, tile_side_length=None)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_urban_land_use(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'urban_land_use.tif')
     target_resolution = get_test_resolution(UrbanLandUse())
@@ -275,7 +275,7 @@ def test_write_urban_land_use(target_folder, sample_aoi):
     UrbanLandUse().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_vegetation_water_map(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'vegetation_water_map.tif')
     target_resolution = get_test_resolution(VegetationWaterMap())
@@ -283,7 +283,7 @@ def test_vegetation_water_map(target_folder, sample_aoi):
     VegetationWaterMap().write(bbox, file_path, spatial_resolution=target_resolution)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_world_pop(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'world_pop.tif')
     target_resolution = get_test_resolution(WorldPop())

--- a/tests/resources/layer_dumps/test_write_layers_by_city.py
+++ b/tests/resources/layer_dumps/test_write_layers_by_city.py
@@ -5,10 +5,10 @@ from city_metrix.constants import testing_aws_bucket_uri
 from city_metrix.layers import *
 from .tools import get_test_bbox
 from ..bbox_constants import EXTENT_SMALL_CITY_WGS84, EXTENT_SMALL_CITY_UTM
-from ..conftest import prep_output_path, EXECUTE_IGNORED_TESTS, verify_file_is_populated
+from ..conftest import prep_output_path, DUMP_RUN_LEVEL, verify_file_is_populated, DumpRunLevel
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_esa_world_cover_os(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     file_path = prep_output_path(target_folder, 'esa_world_cover_small_city_wgs84.tif')
@@ -17,7 +17,7 @@ def test_esa_world_cover_os(target_folder):
     EsaWorldCover(land_cover_class=subclass, year=2020).write(bbox=bbox, output_path=file_path)
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_nasa_dem(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     file_path = prep_output_path(target_folder, 'nasa_dem_small_city_wgs84.tif')
@@ -25,7 +25,7 @@ def test_write_nasa_dem(target_folder):
     NasaDEM().write(bbox, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_nasa_dem_utm(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     file_path = prep_output_path(target_folder, 'nasa_dem_small_city_utm.tif')

--- a/tests/resources/layer_dumps/test_write_layers_by_city_file.py
+++ b/tests/resources/layer_dumps/test_write_layers_by_city_file.py
@@ -5,9 +5,9 @@ from city_metrix.layers import *
 from city_metrix.metrix_dao import get_cache_variables, check_if_cache_file_exists
 from .tools import get_test_bbox, delete_file_on_os
 from ..bbox_constants import EXTENT_SMALL_CITY_WGS84
-from ..conftest import EXECUTE_IGNORED_TESTS, prep_output_path, verify_file_is_populated
+from ..conftest import DUMP_RUN_LEVEL, prep_output_path, verify_file_is_populated, DumpRunLevel
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_AcagPM2p5_file(target_folder):
     set_cache_settings(f"file://{target_folder}", 'dev')
     geo_extent = get_test_bbox(EXTENT_SMALL_CITY_WGS84)

--- a/tests/resources/layer_dumps/test_write_layers_by_city_file.py
+++ b/tests/resources/layer_dumps/test_write_layers_by_city_file.py
@@ -2,7 +2,7 @@ import pytest
 
 from city_metrix.file_cache_config import set_cache_settings
 from city_metrix.layers import *
-from city_metrix.layers.layer_dao import get_cache_variables, check_if_cache_file_exists
+from city_metrix.metrix_dao import get_cache_variables, check_if_cache_file_exists
 from .tools import get_test_bbox, delete_file_on_os
 from ..bbox_constants import EXTENT_SMALL_CITY_WGS84
 from ..conftest import EXECUTE_IGNORED_TESTS, prep_output_path, verify_file_is_populated

--- a/tests/resources/layer_dumps/test_write_layers_by_city_s3.py
+++ b/tests/resources/layer_dumps/test_write_layers_by_city_s3.py
@@ -3,7 +3,7 @@ import pytest
 from city_metrix.file_cache_config import set_cache_settings, clear_cache_settings
 from city_metrix.constants import testing_aws_bucket_uri
 from city_metrix.layers import *
-from city_metrix.layers.layer_dao import get_cache_variables, check_if_cache_file_exists, get_s3_client
+from city_metrix.metrix_dao import get_cache_variables, check_if_cache_file_exists
 from .tools import get_test_bbox, cleanup_cache_files
 from ..bbox_constants import EXTENT_MEDIUM_CITY_WGS84
 from ..conftest import EXECUTE_IGNORED_TESTS, prep_output_path, verify_file_is_populated
@@ -123,24 +123,24 @@ def test_BuiltUpHeight_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
-def test_cams_s3(target_folder):
-    set_cache_settings(testing_aws_bucket_uri, 'dev')
-    geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
-    layer_obj = Cams()
-    file_key, file_uri, layer_id = get_cache_variables(layer_obj, geo_extent)
-    file_path = prep_output_path(target_folder, layer_id)
-    cleanup_cache_files(file_key, file_path)
-    try:
-        layer_obj.write(bbox=geo_extent, output_path=file_uri)
-        s3_file_exists = check_if_cache_file_exists(file_uri)
-        assert s3_file_exists, "Test failed since file did not upload to s3"
-        if s3_file_exists:
-            layer_obj.write(bbox=geo_extent, output_path=file_path)
-            assert verify_file_is_populated(file_path)
-    finally:
-        cleanup_cache_files(file_key, file_path)
-        clear_cache_settings()
+# @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+# def test_cams_s3(target_folder):
+#     set_cache_settings(testing_aws_bucket_uri, 'dev')
+#     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
+#     layer_obj = Cams()
+#     file_key, file_uri, layer_id = get_cache_variables(layer_obj, geo_extent)
+#     file_path = prep_output_path(target_folder, layer_id)
+#     cleanup_cache_files(file_key, file_path)
+#     try:
+#         layer_obj.write(bbox=geo_extent, output_path=file_uri)
+#         s3_file_exists = check_if_cache_file_exists(file_uri)
+#         assert s3_file_exists, "Test failed since file did not upload to s3"
+#         if s3_file_exists:
+#             layer_obj.write(bbox=geo_extent, output_path=file_path)
+#             assert verify_file_is_populated(file_path)
+#     finally:
+#         cleanup_cache_files(file_key, file_path)
+#         clear_cache_settings()
 
 @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
 def test_era5_hottest_day_s3(target_folder):

--- a/tests/resources/layer_dumps/test_write_layers_by_city_s3.py
+++ b/tests/resources/layer_dumps/test_write_layers_by_city_s3.py
@@ -6,9 +6,10 @@ from city_metrix.layers import *
 from city_metrix.metrix_dao import get_cache_variables, check_if_cache_file_exists
 from .tools import get_test_bbox, cleanup_cache_files
 from ..bbox_constants import EXTENT_MEDIUM_CITY_WGS84
-from ..conftest import EXECUTE_IGNORED_TESTS, prep_output_path, verify_file_is_populated
+from ..conftest import DUMP_RUN_LEVEL, DumpRunLevel, prep_output_path, verify_file_is_populated, DumpRunLevel
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_AcagPM2p5_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -28,7 +29,7 @@ def test_AcagPM2p5_s3(target_folder):
         clear_cache_settings()
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_Albedo_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -47,7 +48,7 @@ def test_Albedo_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_AlosDSM_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -66,7 +67,7 @@ def test_AlosDSM_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_AqueductFlood_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -85,7 +86,7 @@ def test_AqueductFlood_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_AverageNetBuildingHeight_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -104,7 +105,7 @@ def test_AverageNetBuildingHeight_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_BuiltUpHeight_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -123,26 +124,26 @@ def test_BuiltUpHeight_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-# @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
-# def test_cams_s3(target_folder):
-#     set_cache_settings(testing_aws_bucket_uri, 'dev')
-#     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
-#     layer_obj = Cams()
-#     file_key, file_uri, layer_id = get_cache_variables(layer_obj, geo_extent)
-#     file_path = prep_output_path(target_folder, layer_id)
-#     cleanup_cache_files(file_key, file_path)
-#     try:
-#         layer_obj.write(bbox=geo_extent, output_path=file_uri)
-#         s3_file_exists = check_if_cache_file_exists(file_uri)
-#         assert s3_file_exists, "Test failed since file did not upload to s3"
-#         if s3_file_exists:
-#             layer_obj.write(bbox=geo_extent, output_path=file_path)
-#             assert verify_file_is_populated(file_path)
-#     finally:
-#         cleanup_cache_files(file_key, file_path)
-#         clear_cache_settings()
+@pytest.mark.skipif(DUMP_RUN_LEVEL != DumpRunLevel.RUN_ALL, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
+def test_cams_s3(target_folder):
+    set_cache_settings(testing_aws_bucket_uri, 'dev')
+    geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
+    layer_obj = Cams()
+    file_key, file_uri, layer_id = get_cache_variables(layer_obj, geo_extent)
+    file_path = prep_output_path(target_folder, layer_id)
+    cleanup_cache_files(file_key, file_path)
+    try:
+        layer_obj.write(bbox=geo_extent, output_path=file_uri)
+        s3_file_exists = check_if_cache_file_exists(file_uri)
+        assert s3_file_exists, "Test failed since file did not upload to s3"
+        if s3_file_exists:
+            layer_obj.write(bbox=geo_extent, output_path=file_path)
+            assert verify_file_is_populated(file_path)
+    finally:
+        cleanup_cache_files(file_key, file_path)
+        clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL != DumpRunLevel.RUN_ALL, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_era5_hottest_day_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -161,7 +162,7 @@ def test_era5_hottest_day_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_EsaWorldCover_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -180,7 +181,7 @@ def test_EsaWorldCover_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_EsaWorldCover_built_up_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -200,7 +201,7 @@ def test_EsaWorldCover_built_up_s3(target_folder):
         clear_cache_settings()
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_HeightAboveNearestDrainage_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -219,7 +220,7 @@ def test_HeightAboveNearestDrainage_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_HighLandSurfaceTemperature_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -238,7 +239,7 @@ def test_HighLandSurfaceTemperature_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_HighSlope_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -257,7 +258,7 @@ def test_HighSlope_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_ImperviousSurface_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -276,7 +277,7 @@ def test_ImperviousSurface_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_LandCoverGlad_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -295,7 +296,7 @@ def test_LandCoverGlad_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_LandCoverSimplifiedGlad_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -314,7 +315,7 @@ def test_LandCoverSimplifiedGlad_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_LandCoverHabitatGlad_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -333,7 +334,7 @@ def test_LandCoverHabitatGlad_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_LandCoverHabitatChangeGlad_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -352,7 +353,7 @@ def test_LandCoverHabitatChangeGlad_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_LandSurfaceTemperature_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -372,7 +373,7 @@ def test_LandSurfaceTemperature_s3(target_folder):
         clear_cache_settings()
 
 # # TODO Determine how to write out file from temporal dataset
-# @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+# @pytest.mark.skipif(TEST_RUN_LEVEL != TestRunLevel.RUN_ALL, reason=f"Skipping since TEST_RUN_LEVEL set to {TEST_RUN_LEVEL}")
 # def test_LandsatCollection2_s3(target_folder):
 #     set_cache_settings(testing_aws_bucket_uri, 'dev')
 #     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -391,7 +392,7 @@ def test_LandSurfaceTemperature_s3(target_folder):
 #         cleanup_cache_files(file_key, file_path)
 #         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_NasaDEM_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -410,7 +411,7 @@ def test_NasaDEM_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_NaturalAreas_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -429,7 +430,7 @@ def test_NaturalAreas_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_NdviSentinel2_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -448,7 +449,7 @@ def test_NdviSentinel2_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_OpenBuildings_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -467,7 +468,7 @@ def test_OpenBuildings_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_OpenStreetMap_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -486,7 +487,7 @@ def test_OpenStreetMap_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_OvertureBuildings_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -505,7 +506,7 @@ def test_OvertureBuildings_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_PopWeightedPM2p5_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -524,7 +525,7 @@ def test_PopWeightedPM2p5_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_ProtectedAreas_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -543,7 +544,7 @@ def test_ProtectedAreas_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_RiparianAreas_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -563,7 +564,7 @@ def test_RiparianAreas_s3(target_folder):
         clear_cache_settings()
 
 # # TODO Determine how to write out file from temporal dataset
-# @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+# @pytest.mark.skipif(TEST_RUN_LEVEL != TestRunLevel.RUN_ALL, reason=f"Skipping since TEST_RUN_LEVEL set to {TEST_RUN_LEVEL}")
 # def test_Sentinel2Level2_s3(target_folder):
 #     set_cache_settings(testing_aws_bucket_uri, 'dev')
 #     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -584,7 +585,7 @@ def test_RiparianAreas_s3(target_folder):
 
 # TODO Very long runtime
 # TODO Run fails. Appears to be a memory issue
-# @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+# @pytest.mark.skipif(TEST_RUN_LEVEL != TestRunLevel.RUN_ALL, reason=f"Skipping since TEST_RUN_LEVEL set to {TEST_RUN_LEVEL}")
 # def test_SmartSurfaceLULC_s3(target_folder):
 #     set_cache_settings(testing_aws_bucket_uri, 'dev')
 #     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -604,7 +605,7 @@ def test_RiparianAreas_s3(target_folder):
 #         clear_cache_settings()
 
 # TODO Long runtime
-# @pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+# @pytest.mark.skipif(TEST_RUN_LEVEL != TestRunLevel.RUN_ALL, reason=f"Skipping since TEST_RUN_LEVEL set to {TEST_RUN_LEVEL}")
 # def test_TreeCanopyHeight_s3(target_folder):
 #     set_cache_settings(testing_aws_bucket_uri, 'dev')
 #     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -623,7 +624,7 @@ def test_RiparianAreas_s3(target_folder):
 #         cleanup_cache_files(file_key, file_path)
 #         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_TreeCover_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -642,7 +643,7 @@ def test_TreeCover_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_UrbanExtents_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -661,7 +662,7 @@ def test_UrbanExtents_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_UrbanLandUse_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -681,7 +682,7 @@ def test_UrbanLandUse_s3(target_folder):
         clear_cache_settings()
 
 # TODO Fails for:  # layer_obj = VegetationWaterMap(start_date='2020-01-01', end_date='2020-12-31')
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_VegetationWaterMap_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)
@@ -700,7 +701,7 @@ def test_VegetationWaterMap_s3(target_folder):
         cleanup_cache_files(file_key, file_path)
         clear_cache_settings()
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_WorldPop_s3(target_folder):
     set_cache_settings(testing_aws_bucket_uri, 'dev')
     geo_extent = get_test_bbox(EXTENT_MEDIUM_CITY_WGS84)

--- a/tests/resources/layer_dumps/test_write_layers_other.py
+++ b/tests/resources/layer_dumps/test_write_layers_other.py
@@ -4,11 +4,11 @@ import pytest
 import xarray as xr
 
 from city_metrix.layers import *
-from tests.resources.conftest import EXECUTE_IGNORED_TESTS, prep_output_path, get_file_count_in_folder
+from tests.resources.conftest import DUMP_RUN_LEVEL, prep_output_path, get_file_count_in_folder, DumpRunLevel
 from .tools import get_test_bbox, get_test_resolution
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_albedo_tiled_unbuffered(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'albedo_tiled.tif')
     target_resolution = get_test_resolution(Albedo())
@@ -21,7 +21,7 @@ def test_write_albedo_tiled_unbuffered(target_folder, sample_aoi):
     expected_file_count = 3 # includes 2 tiles and one json file
     assert file_count == expected_file_count
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_albedo_tiled_buffered(target_folder, sample_aoi):
     buffer_degrees = 0.001
     file_path = prep_output_path(target_folder, 'albedo_tiled_buffered.tif')
@@ -36,7 +36,7 @@ def test_write_albedo_tiled_buffered(target_folder, sample_aoi):
     assert file_count == expected_file_count
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_nasa_dem_tiled_unbuffered(target_folder, sample_aoi):
     file_path = prep_output_path(target_folder, 'nasa_dem_tiled_unbuffered.tif')
     target_resolution = get_test_resolution(NasaDEM())
@@ -51,7 +51,7 @@ def test_write_nasa_dem_tiled_unbuffered(target_folder, sample_aoi):
     assert file_count == expected_file_count
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since TEST_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_get_nasa_dem_bicubic(target_folder, sample_aoi):
     utm_bbox = get_test_bbox(sample_aoi.geo_extent).as_utm_bbox()
     data = NasaDEM().get_data(utm_bbox, spatial_resolution=30, resampling_method='bicubic')

--- a/tests/resources/layer_dumps/tools.py
+++ b/tests/resources/layer_dumps/tools.py
@@ -1,7 +1,7 @@
 import os
 
 from city_metrix.file_cache_config import get_aws_bucket_name
-from city_metrix.layers.layer_dao import get_s3_client
+from city_metrix.metrix_dao import get_s3_client
 from tests.resources.conftest import RESOLUTION_MTHD, FIXED_RESOLUTION, RESOLUTION_MULTIPLIER, USE_WGS_BBOX
 from tests.tools.general_tools import get_class_default_spatial_resolution
 

--- a/tests/resources/metrics_dumps/test_write_all_metrics.py
+++ b/tests/resources/metrics_dumps/test_write_all_metrics.py
@@ -6,7 +6,7 @@ import pytest
 from city_metrix.metrics import *
 from tests.conftest import create_fishnet_grid_for_testing
 from tests.resources.bbox_constants import BBOX_IDN_JAKARTA, BBOX_IDN_JAKARTA_LARGE
-from tests.resources.conftest import prep_output_path, verify_file_is_populated, EXECUTE_IGNORED_TESTS
+from tests.resources.conftest import prep_output_path, verify_file_is_populated, DUMP_RUN_LEVEL, DumpRunLevel
 from tests.tools.general_tools import create_target_folder
 
 SAMPLE_TILED_SINGLE_ZONE = (
@@ -21,7 +21,7 @@ SAMPLE_TILED_LARGE_ZONES = (
 # TODO - groupby fails for small zones that return null values from AcagPM2p5 layer. How should system handle such nulls
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_built_land_with_high_land_surface_temperature(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -31,7 +31,7 @@ def test_write_built_land_with_high_land_surface_temperature(target_folder):
     BuiltLandWithHighLST().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_built_land_with_low_surface_reflectivity(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -41,7 +41,7 @@ def test_write_built_land_with_low_surface_reflectivity(target_folder):
     BuiltLandWithLowSurfaceReflectivity().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_built_land_without_tree_cover(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -52,7 +52,7 @@ def test_write_built_land_without_tree_cover(target_folder):
     assert verify_file_is_populated(file_path)
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_canopy_area_per_resident_children(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -62,7 +62,7 @@ def test_write_canopy_area_per_resident_children(target_folder):
     CanopyAreaPerResidentChildren().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_canopy_area_per_resident_elderly(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -72,7 +72,7 @@ def test_write_canopy_area_per_resident_elderly(target_folder):
     CanopyAreaPerResidentElderly().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_canopy_area_per_resident_female(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -82,7 +82,7 @@ def test_write_canopy_area_per_resident_female(target_folder):
     CanopyAreaPerResidentFemale().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_canopy_area_per_resident_informal(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -92,7 +92,7 @@ def test_write_canopy_area_per_resident_informal(target_folder):
     CanopyAreaPerResidentInformal().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_era_5_met_preprocessing(target_folder):
     zones = SAMPLE_TILED_SINGLE_ZONE
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -102,7 +102,7 @@ def test_write_era_5_met_preprocessing(target_folder):
     Era5MetPreprocessing().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_mean_pm2p5_exposure_pop_weighted_children(target_folder):
     zones = SAMPLE_TILED_LARGE_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -112,6 +112,7 @@ def test_write_mean_pm2p5_exposure_pop_weighted_children(target_folder):
     MeanPM2P5ExposurePopWeightedChildren().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_mean_pm2p5_exposure_pop_weighted_elderly(target_folder):
     zones = SAMPLE_TILED_LARGE_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -121,6 +122,7 @@ def test_write_mean_pm2p5_exposure_pop_weighted_elderly(target_folder):
     MeanPM2P5ExposurePopWeightedElderly().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_mean_pm2p5_exposure_pop_weighted_female(target_folder):
     zones = SAMPLE_TILED_LARGE_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -130,6 +132,7 @@ def test_write_mean_pm2p5_exposure_pop_weighted_female(target_folder):
     MeanPM2P5ExposurePopWeightedFemale().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_mean_pm2p5_exposure_pop_weighted_informal(target_folder):
     zones = SAMPLE_TILED_LARGE_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -139,7 +142,7 @@ def test_write_mean_pm2p5_exposure_pop_weighted_informal(target_folder):
     MeanPM2P5ExposurePopWeightedInformal().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_mean_tree_cover(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -149,7 +152,7 @@ def test_write_mean_tree_cover(target_folder):
     MeanTreeCover().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_natural_areas(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -159,7 +162,7 @@ def test_write_natural_areas(target_folder):
     NaturalAreasPercent().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_percent_area_impervious(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -170,7 +173,7 @@ def test_write_percent_area_impervious(target_folder):
     assert verify_file_is_populated(file_path)
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_percent_protected_area(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -181,7 +184,7 @@ def test_write_percent_protected_area(target_folder):
     assert verify_file_is_populated(file_path)
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_recreational_space_per_capita(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -192,7 +195,7 @@ def test_write_recreational_space_per_capita(target_folder):
     assert verify_file_is_populated(file_path)
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_urban_open_space(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -203,7 +206,7 @@ def test_write_urban_open_space(target_folder):
     assert verify_file_is_populated(file_path)
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_vegetation_water_change_gain_area(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -213,7 +216,7 @@ def test_write_vegetation_water_change_gain_area(target_folder):
     VegetationWaterChangeGainArea().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_vegetation_water_change_loss_area(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -223,7 +226,7 @@ def test_write_vegetation_water_change_loss_area(target_folder):
     VegetationWaterChangeLossArea().write_as_geojson(zones, file_path)
     assert verify_file_is_populated(file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_vegetation_water_change_gain_loss_ratio(target_folder):
     zones = SAMPLE_TILED_ZONES
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))

--- a/tests/resources/metrics_dumps/test_write_metrics_variants.py
+++ b/tests/resources/metrics_dumps/test_write_metrics_variants.py
@@ -6,7 +6,7 @@ import pytest
 
 from city_metrix.constants import WGS_CRS
 from city_metrix.metrics import *
-from tests.resources.conftest import prep_output_path, verify_file_is_populated, EXECUTE_IGNORED_TESTS
+from tests.resources.conftest import prep_output_path, verify_file_is_populated, DUMP_RUN_LEVEL, DumpRunLevel
 from tests.tools.general_tools import create_target_folder
 
 from shapely.geometry import Polygon
@@ -21,7 +21,7 @@ IDN_Jakarta_zone = (gpd.GeoDataFrame([Polygon(jakarta_crude_boundary)], columns=
                     .reset_index())
 
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_polygonal_zones(target_folder):
     zone = IDN_Jakarta_zone
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -36,7 +36,7 @@ def test_write_polygonal_zones(target_folder):
     actual_indicator_size = indicator.size
     assert expected_zone_size == actual_indicator_size
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_data_series_as_geojson(target_folder):
     zones = IDN_Jakarta_zone
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))
@@ -46,7 +46,7 @@ def test_write_data_series_as_geojson(target_folder):
     BuiltLandWithHighLST().write_as_geojson(zones,csv_file_path)
     assert verify_file_is_populated(csv_file_path)
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason='Skipping since EXECUTE_IGNORED_TESTS set to False')
+@pytest.mark.skipif(DUMP_RUN_LEVEL == DumpRunLevel.RUN_NONE, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_data_series_as_csv(target_folder):
     zones = IDN_Jakarta_zone
     target_metrics_folder = str(os.path.join(target_folder, 'metrics'))

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from city_metrix.layers import *
 from city_metrix.layers.layer_tools import get_projection_name
-from tests.conftest import EXECUTE_IGNORED_TESTS
+from tests.conftest import TestRunLevel, TEST_RUN_LEVEL
 from tests.resources.bbox_constants import BBOX_BRA_LAURO_DE_FREITAS_1, BBOX_USA_OR_PORTLAND_2, EXTENT_SMALL_CITY_WGS84
 from tests.tools.spatial_tools import get_rounded_gdf_geometry
 
@@ -54,14 +54,14 @@ def test_built_up_height():
     utm_bbox_data = BuiltUpHeight().get_data(BBOX_AS_UTM)
     assert get_rounded_gdf_geometry(data, 1).equals(get_rounded_gdf_geometry(utm_bbox_data, 1))
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason="CDS API needs personal access token file to run")
+@pytest.mark.skipif(TEST_RUN_LEVEL != TestRunLevel.RUN_ALL, reason="CDS API needs personal access token file to run")
 def test_cams():
     data = Cams().get_data(BBOX)
     assert np.size(data) > 0
     utm_bbox_data = Cams().get_data(BBOX_AS_UTM)
     assert get_rounded_gdf_geometry(data, 1).equals(get_rounded_gdf_geometry(utm_bbox_data, 1))
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason="CDS API needs personal access token file to run")
+@pytest.mark.skipif(TEST_RUN_LEVEL != TestRunLevel.RUN_ALL, reason="CDS API needs personal access token file to run")
 def test_era_5_hottest_day():
     data = Era5HottestDay().get_data(BBOX)
     assert np.size(data) > 0
@@ -207,6 +207,7 @@ def test_riparian_areas():
     utm_bbox_data = RiparianAreas().get_data(BBOX_AS_UTM)
     assert get_rounded_gdf_geometry(data, 1).equals(get_rounded_gdf_geometry(utm_bbox_data, 1))
 
+# TODO is this layer deprecated?
 @pytest.mark.skip(reason="layer is deprecated")
 def test_sentinel_2_level2():
     sentinel_2_bands = ["green"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,6 @@
 from city_metrix.metrics import *
-from .conftest import IDN_JAKARTA_TILED_ZONES, EXECUTE_IGNORED_TESTS, USA_OR_PORTLAND_TILE_GDF, NLD_AMSTERDAM_TILE_GDF
+from .conftest import IDN_JAKARTA_TILED_ZONES, USA_OR_PORTLAND_TILE_GDF, NLD_AMSTERDAM_TILE_GDF, \
+    TestRunLevel, TEST_RUN_LEVEL
 import pytest
 
 
@@ -48,7 +49,7 @@ def test_canopy_area_per_resident_informal():
     actual_indicator_size = indicator.size
     assert expected_zone_size == actual_indicator_size
 
-@pytest.mark.skipif(EXECUTE_IGNORED_TESTS == False, reason="CDS API needs personal access token file to run")
+@pytest.mark.skipif(TEST_RUN_LEVEL != TestRunLevel.RUN_ALL, reason="CDS API needs personal access token file to run")
 def test_era_5_met_preprocess():
     # Useful site: https://projects.oregonlive.com/weather/temps/
     indicator = Era5MetPreprocessing().get_data(USA_OR_PORTLAND_TILE_GDF)


### PR DESCRIPTION
## Did you read the Contributor Guide?
- Yes, I have read [How to contribute](https://github.com/wri/cities-cif#How-to-contribute)

## Is this PR related to a JIRA ticket?
Yes, [CDB-83](https://gfw.atlassian.net/browse/CDB-83) 

## What changes were proposed in this PR?
Second phase of adding S3 caching for Metrics. This phase:
  a. Merged some Layers and Metrics functionality
  b. Improved control options for running tests. Now, all optional tests can be run or just the faster-running ones. This allows exclusion of CAMS and ERA5 in some testing runs during development work.

## How was this patch tested?
On local laptop. CIF-Portal does not currently support Metrics, so not tested with it.

## Did this PR include necessary documentation updates?
Yes in ReleaseNotes

[CDB-83]: https://gfw.atlassian.net/browse/CDB-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ