### PR TITLE
Modifid to handle 1:2 overture to Globus building relation

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2025/05/24
+1. CDB-322. Fixed error in UTGlobus-to-Overture conflation that had produced many-to-one matches and resulting errors in height computation.
+2. Modified computation of UTGlobus heights to use mode or median computation. See updated https://gfw.atlassian.net/wiki/spaces/CIT/pages/1971912734/Primary+Raster+Layers+for+Thermal+Comfort+Modeling
+
 ## 2025/05/12
 1. Moved OpenUrban layer from C-TCM to CIF. Former location: https://github.com/wri/cities-thermal-comfort-modeling/blob/main/src/workers/open_urban.py
 

--- a/city_metrix/layers/overture_buildings_w_height.py
+++ b/city_metrix/layers/overture_buildings_w_height.py
@@ -102,19 +102,19 @@ def _join_overture_and_utglobus(overture_buildings, ut_globus):
     # Explicitly handle the unique uri_scheme for each row
     joined_data["id"] = joined_data.apply(lambda row: row["id"] if "id" in row else row.name, axis=1)
 
-    # Get mode of heights from UT Globus for buildings that overlapped with UTGlobus buildings
+    # Get mode or median of heights from UT Globus for buildings that overlapped with UTGlobus buildings
     filtered_data = joined_data.dropna(subset=['utglobus_height'])
-    mode_df  = filtered_data.groupby('id')['utglobus_height'].apply(mode_or_median).reset_index()
-    merged_gdf = filtered_data.merge(mode_df.rename(columns={'utglobus_height': 'mode_utglobus_height'}), on='id')
+    mode_or_median_df  = filtered_data.groupby('id')['utglobus_height'].apply(mode_or_median).reset_index()
+    merged_gdf = filtered_data.merge(mode_or_median_df.rename(columns={'utglobus_height': 'mode_or_med_utglobus_height'}), on='id')
     overture_with_globus_height = merged_gdf.drop(columns=['utglobus_height', 'height']).drop_duplicates()
-    overture_with_globus_height['height'] = overture_with_globus_height['mode_utglobus_height']
+    overture_with_globus_height['height'] = overture_with_globus_height['mode_or_med_utglobus_height']
     # Assign source as UTGlobus
     overture_with_globus_height['height_source'] = 'UTGlobus'
 
     # Get buildings that did not overlap with a UTGlobus value
-    overture_without_globus_height = joined_data[~joined_data['id'].isin(mode_df['id'])]
+    overture_without_globus_height = joined_data[~joined_data['id'].isin(mode_or_median_df['id'])]
     overture_without_globus_height = overture_without_globus_height.drop(columns=['utglobus_height'])
-    overture_without_globus_height['mode_utglobus_height'] = np.nan
+    overture_without_globus_height['mode_or_med_utglobus_height'] = np.nan
     overture_without_globus_height['height_source'] = np.where(overture_without_globus_height['overture_height'].notna(), 'Overture', '')
 
     # Combine Globus and non-Globus records

--- a/tests/test_layer_variants.py
+++ b/tests/test_layer_variants.py
@@ -2,11 +2,11 @@ import ee
 import numpy as np
 import pytest
 
-from city_metrix.constants import ProjectionType
-from city_metrix.layers import NdviSentinel2, TreeCover, Albedo, AlosDSM, UtGlobus
+from city_metrix.constants import ProjectionType, WGS_CRS
+from city_metrix.layers import NdviSentinel2, TreeCover, Albedo, AlosDSM, UtGlobus, OvertureBuildingsHeight
 from city_metrix.metrix_tools import get_projection_type
 from tests.resources.bbox_constants import BBOX_BRA_LAURO_DE_FREITAS_1, BBOX_USA_OR_PORTLAND_2
-from city_metrix.metrix_model import get_image_collection
+from city_metrix.metrix_model import get_image_collection, GeoExtent
 from tests.test_layers import assert_vector_stats
 
 EE_IMAGE_DIMENSION_TOLERANCE = 1  # Tolerance compensates for variable results from GEE service
@@ -120,6 +120,15 @@ def test_ut_globus_blank_city():
     data = UtGlobus().get_data(BBOX_USA_OR_PORTLAND_2)
     assert np.size(data) > 0
     assert_vector_stats(data, 'height', 0, 3, 16, 1095, 0)
+
+
+def test_overture_height_rio():
+    # tests an area with many overlapping buildings between UTGlobus and Overture
+    city = 'rio_de_janerio'
+    rio_bbox = GeoExtent(bbox=(-43.17135,-22.90901, -43.16832,-22.90598), crs=WGS_CRS)
+    data = OvertureBuildingsHeight(city).get_data(rio_bbox)
+    assert np.size(data) > 0
+    assert_vector_stats(data, 'height', 1, 3.5, 436, 43, 0)
 
 
 def _convert_fraction_to_rounded_percent(fraction):


### PR DESCRIPTION
See https://gfw.atlassian.net/browse/CDB-322

This class had been returning duplicate records where a given Overture building intersected with multiple UTGlobus buildings. Code is now modified to get the mode height for such situations for the UTGlobus heights.