### PR TITLE
Print all pytest durations in Github Actions

### DIFF
--- a/.github/workflows/dev_ci_cd_conda.yml
+++ b/.github/workflows/dev_ci_cd_conda.yml
@@ -39,4 +39,4 @@ jobs:
         GOOGLE_APPLICATION_USER: ${{ secrets.GOOGLE_APPLICATION_USER }}
         GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       run: |
-          pytest --durations=10
+          pytest --durations=0


### PR DESCRIPTION
I think it will be nice for troubleshooting to see all the test durations. 

Hopefully it doesn't make it take any longer to run.