### PR TITLE
CIF-339 add Key Biodiversity Areas layer

### DIFF
--- a/city_metrix/layers/__init__.py
+++ b/city_metrix/layers/__init__.py
@@ -15,6 +15,7 @@ from .height_above_nearest_drainage import HeightAboveNearestDrainage
 from .high_land_surface_temperature import HighLandSurfaceTemperature
 from .high_slope import HighSlope
 from .impervious_surface import ImperviousSurface
+from .key_biodiversity_areas import KeyBiodiversityAreas
 from .land_surface_temperature import LandSurfaceTemperature
 from .landsat_collection_2 import LandsatCollection2
 from .nasa_dem import NasaDEM

--- a/city_metrix/layers/key_biodiversity_areas.py
+++ b/city_metrix/layers/key_biodiversity_areas.py
@@ -1,0 +1,35 @@
+from geopandas import GeoDataFrame
+from city_metrix.metrix_model import Layer, get_image_collection, GeoExtent
+from ..constants import GEOJSON_FILE_EXTENSION
+
+AWS_STEM = 'https://wri-cities-indicators.s3.us-east-1.amazonaws.com'
+S3_KBA_PREFIX = 'devdata/inputdata/KBA'
+
+class KeyBiodiversityAreas(Layer):
+    OUTPUT_FILE_FORMAT = GEOJSON_FILE_EXTENSION
+    MAJOR_NAMING_ATTS = ['SitRecID']
+    MINOR_NAMING_ATTS = []
+
+    """
+    Attributes:
+        SitRecID: ID num at BirdLife International
+    """
+
+    def __init__(self, country_code_iso3=None, **kwargs):
+        super().__init__(**kwargs)
+        self.country_code_iso3 = country_code_iso3
+
+    def get_data(self, bbox: GeoExtent, spatial_resolution=None, resampling_method=None,
+                 force_data_refresh=False):
+        if self.country_code_iso3 is not None:
+            country_code = self.country_code_iso3
+        else:
+            country_code = 'global'
+
+        utm_crs = bbox.as_utm_bbox().crs
+
+        country_data = GeoDataFrame.from_file(f'{AWS_STEM}/{S3_KBA_PREFIX}/KBA_{country_code}.geojson')
+        data = country_data.loc[country_data.intersects(bbox.as_geographic_bbox().polygon)]
+        data = data.to_crs(utm_crs).reset_index()
+
+        return data

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -145,6 +145,14 @@ def test_impervious_surface():
     utm_bbox_data = ImperviousSurface().get_data(BBOX_AS_UTM)
     assert get_rounded_gdf_geometry(data, 1).equals(get_rounded_gdf_geometry(utm_bbox_data, 1))
 
+def test_key_biodiversity_areas():
+    data = KeyBiodiversityAreas('USA').get_data(BBOX)
+    assert np.size(data) > 0
+    assert_vector_stats(data, 'area_in_meters', 1, 8.1, 15967.0, 1111, 0)
+    assert get_projection_type(data.crs.srs) == ProjectionType.UTM
+    utm_bbox_data = OpenBuildings(COUNTRY_CODE_FOR_BBOX).get_data(BBOX_AS_UTM)
+    assert get_rounded_gdf_geometry(data, 1).equals(get_rounded_gdf_geometry(utm_bbox_data, 1))
+
 def test_land_cover_glad():
     data = LandCoverGlad().get_data(BBOX)
     assert np.size(data) > 0


### PR DESCRIPTION
This is a new layer for Key Biodiversity Layer. Reads from a geojson stored on S3, and returns geojson that intersects with given bbox.

The source data should not be presented in a map. We do not have permission to display the source data--only our derived metric.