### PR TITLE
Cdb 393 partial set of metric values for low resolution metrics

### DIFF
--- a/city_metrix/layers/acag_pm2p5.py
+++ b/city_metrix/layers/acag_pm2p5.py
@@ -3,7 +3,7 @@ import ee
 from city_metrix.metrix_model import Layer, get_image_collection, GeoExtent
 from ..constants import GTIFF_FILE_EXTENSION
 
-DEFAULT_SPATIAL_RESOLUTION = 1113.1949  # 10 degrees of earth circumference
+DEFAULT_SPATIAL_RESOLUTION = 10
 
 
 class AcagPM2p5(Layer):

--- a/city_metrix/metrix_model.py
+++ b/city_metrix/metrix_model.py
@@ -131,10 +131,7 @@ class GeoExtent():
             else:
                 self.crs = crs
 
-            try:
-                self.epsg_code = int(self.crs.split(':')[1])
-            except:
-                b=2
+            self.epsg_code = int(self.crs.split(':')[1])
             self.projection_type = get_projection_type(self.crs)
             self.units = "degrees" if self.projection_type == ProjectionType.GEOGRAPHIC else "meters"
             self.bounds = self.bbox
@@ -666,8 +663,8 @@ class LayerGroupBy:
                     "x": align_to.x,
                     "y": align_to.y,
                 })
-            except Exception as e:
-                b=2
+            except Exception as e_msg:
+                raise Exception(f"Unable to align data due to exception: {e_msg}")
         elif isinstance(data_layer, gpd.GeoDataFrame):
             gdf = data_layer.to_crs(align_to.rio.crs).reset_index()
             return LayerGroupBy._rasterize(gdf, align_to)

--- a/city_metrix/metrix_model.py
+++ b/city_metrix/metrix_model.py
@@ -581,7 +581,7 @@ class LayerGroupBy:
                                                          spatial_resolution=spatial_resolution,
                                                          force_data_refresh=force_data_refresh)
 
-        if aggregate_data.data.size == 0:
+        if isinstance(aggregate_data, xr.DataArray) and aggregate_data.data.size == 0:
             return None
         else:
             mask_datum = [mask.get_data_with_caching(bbox=bbox, s3_env=DEFAULT_PRODUCTION_ENV,

--- a/city_metrix/metrix_model.py
+++ b/city_metrix/metrix_model.py
@@ -44,7 +44,11 @@ class GeoZone():
             self.aoi_id = None
             self.admin_level = None
             self.zones = geo_zone
-            self.bbox = geo_zone.total_bounds
+            if hasattr(geo_zone, 'total_bounds'):
+                self.bbox = geo_zone.total_bounds
+            else:
+                self.bbox = geo_zone.bounds
+
             self.crs = crs
         else:
             city_json = geo_zone
@@ -577,65 +581,70 @@ class LayerGroupBy:
                                                          spatial_resolution=spatial_resolution,
                                                          force_data_refresh=force_data_refresh)
 
-        mask_datum = [mask.get_data_with_caching(bbox=bbox, s3_env=DEFAULT_PRODUCTION_ENV,
-                                                 spatial_resolution=spatial_resolution,
-                                                 force_data_refresh=force_data_refresh) for mask in masks]
-
-        if layer is not None:
-            layer_data = layer.get_data_with_caching(bbox=bbox, s3_env=DEFAULT_PRODUCTION_ENV,
+        if aggregate_data.data.size == 0:
+            return None
+        else:
+            mask_datum = [mask.get_data_with_caching(bbox=bbox, s3_env=DEFAULT_PRODUCTION_ENV,
                                                      spatial_resolution=spatial_resolution,
-                                                     force_data_refresh=force_data_refresh)
-        else:
-            layer_data = None
+                                                     force_data_refresh=force_data_refresh) for mask in masks]
 
-        # align to highest resolution raster, which should be the largest raster
-        # since all are clipped to the extent
-        raster_data = [data for data in mask_datum + [aggregate_data] + [layer_data] if isinstance(data, xr.DataArray)]
-        align_to = sorted(raster_data, key=lambda data: data.size, reverse=True).pop()
-        aggregate_data = LayerGroupBy._align(aggregate_data, align_to)
-        mask_datum = [LayerGroupBy._align(data, align_to) for data in mask_datum]
+            if layer is not None:
+                layer_data = layer.get_data_with_caching(bbox=bbox, s3_env=DEFAULT_PRODUCTION_ENV,
+                                                         spatial_resolution=spatial_resolution,
+                                                         force_data_refresh=force_data_refresh)
+            else:
+                layer_data = None
 
-        if layer is not None:
-            layer_data = LayerGroupBy._align(layer_data, align_to)
+            # align to highest resolution raster, which should be the largest raster
+            # since all are clipped to the extent
+            raster_data = [data for data in mask_datum + [aggregate_data] + [layer_data] if isinstance(data, xr.DataArray)]
+            align_to = sorted(raster_data, key=lambda data: data.size, reverse=True).pop()
+            aligned_aggregate_data = LayerGroupBy._align(aggregate_data, align_to)
+            aligned_mask_datum = [LayerGroupBy._align(data, align_to) for data in mask_datum]
 
-        for mask in mask_datum:
-            aggregate_data = aggregate_data.where(~np.isnan(mask))
+            if layer is not None:
+                aligned_layer_data = LayerGroupBy._align(layer_data, align_to)
+            else:
+                aligned_layer_data = None
 
-        # Get zones differently for single or multiple tiles
-        if isinstance(tile_gdf, GeoDataFrame):
-            tile_gdf = tile_gdf
-        else:
-            tile_gdf = tile_gdf.zones
+            for mask in aligned_mask_datum:
+                aligned_aggregate_data = aligned_aggregate_data.where(~np.isnan(mask))
 
-        result_stats = None
-        if 'geo_level' not in zones.columns:
-            result_stats = LayerGroupBy._compute_zonal_stats(stats_func, layer, tile_gdf, align_to, layer_data,
-                                                             aggregate_data)
-        else:
-            geo_levels = zones['geo_level'].unique()
-            for index, level in enumerate(geo_levels):
-                level_gdf = tile_gdf[tile_gdf['geo_level'] == level]
+            # Get zones differently for single or multiple tiles
+            if isinstance(tile_gdf, GeoDataFrame):
+                tile_gdf = tile_gdf
+            else:
+                tile_gdf = tile_gdf.zones
 
-                stats = LayerGroupBy._compute_zonal_stats(stats_func, layer, level_gdf, align_to, layer_data,
-                                                          aggregate_data)
+            result_stats = None
+            if 'geo_level' not in zones.columns:
+                result_stats = LayerGroupBy._compute_zonal_stats(stats_func, layer, tile_gdf, align_to, aligned_layer_data,
+                                                                 aligned_aggregate_data)
+            else:
+                geo_levels = zones['geo_level'].unique()
+                for index, level in enumerate(geo_levels):
+                    level_gdf = tile_gdf[tile_gdf['geo_level'] == level]
 
-                # combine stats from each geo_level
-                if result_stats is None:
-                    result_stats = stats
-                else:
-                    # if metric values for a prior level are already in the results data, then merge in the new stats,
-                    # then combine them into a single column.
-                    merged_df = pd.merge(result_stats, stats, on='zone', how='outer')
+                    stats = LayerGroupBy._compute_zonal_stats(stats_func, layer, level_gdf, align_to, aligned_layer_data,
+                                                              aligned_aggregate_data)
 
-                    for func in stats_func:
-                        func_x_col = f"{func}_x"
-                        func_y_col = f"{func}_y"
-                        merged_df[func] = merged_df[func_x_col].combine_first(merged_df[func_y_col])
+                    # combine stats from each geo_level
+                    if result_stats is None:
+                        result_stats = stats
+                    else:
+                        # if metric values for a prior level are already in the results data, then merge in the new stats,
+                        # then combine them into a single column.
+                        merged_df = pd.merge(result_stats, stats, on='zone', how='outer')
 
-                        merged_df = merged_df.drop(columns=[func_x_col, func_y_col])
-                    result_stats = merged_df
+                        for func in stats_func:
+                            func_x_col = f"{func}_x"
+                            func_y_col = f"{func}_y"
+                            merged_df[func] = merged_df[func_x_col].combine_first(merged_df[func_y_col])
 
-        return result_stats
+                            merged_df = merged_df.drop(columns=[func_x_col, func_y_col])
+                        result_stats = merged_df
+
+            return result_stats
 
     @staticmethod
     def _compute_zonal_stats(stats_func, layer, tile_gdf, align_to, layer_data, aggregate_data):
@@ -652,10 +661,13 @@ class LayerGroupBy:
     @staticmethod
     def _align(data_layer, align_to):
         if isinstance(data_layer, xr.DataArray):
-            return data_layer.rio.reproject_match(align_to).assign_coords({
-                "x": align_to.x,
-                "y": align_to.y,
-            })
+            try:
+                return data_layer.rio.reproject_match(align_to).assign_coords({
+                    "x": align_to.x,
+                    "y": align_to.y,
+                })
+            except Exception as e:
+                b=2
         elif isinstance(data_layer, gpd.GeoDataFrame):
             gdf = data_layer.to_crs(align_to.rio.crs).reset_index()
             return LayerGroupBy._rasterize(gdf, align_to)

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.10.16
   - earthengine-api=1.5.9
   - geocube=0.7.1
-  - geopandas=1.0.1
+  - geopandas=1.1.1
   - gdal=3.10.2
   - xarray=2025.3.1
   - rioxarray=0.18.2

--- a/tests/resources/metrics_dumps/test_write_all_metrics_by_city.py
+++ b/tests/resources/metrics_dumps/test_write_all_metrics_by_city.py
@@ -79,6 +79,11 @@ def test_write_MeanPM2P5Exposure(target_folder):
     _run_write_metrics_by_city_test(metric_obj, target_folder, GEOEXTENT_TERESINA, GEOZONE_TERESINA)
 
 @pytest.mark.skipif(DUMP_RUN_LEVEL != DumpRunLevel.RUN_FAST_ONLY, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
+def test_write_MeanPM2P5ExposurePopWeighted(target_folder):
+    metric_obj = MeanPM2P5ExposurePopWeighted()
+    _run_write_metrics_by_city_test(metric_obj, target_folder, GEOEXTENT_TERESINA, GEOZONE_TERESINA)
+
+@pytest.mark.skipif(DUMP_RUN_LEVEL != DumpRunLevel.RUN_FAST_ONLY, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
 def test_write_MeanPM2P5ExposurePopWeightedElderly(target_folder):
     metric_obj = MeanPM2P5ExposurePopWeightedElderly()
     _run_write_metrics_by_city_test(metric_obj, target_folder, GEOEXTENT_TERESINA, GEOZONE_TERESINA)

--- a/tests/resources/metrics_dumps/test_write_all_metrics_by_city.py
+++ b/tests/resources/metrics_dumps/test_write_all_metrics_by_city.py
@@ -15,7 +15,7 @@ PRESERVE_RESULTS_ON_OS = False  # False - Default for check-in
 OUTPUT_RESULTS_FORMAT = 'csv' # Default for check-in
 # OUTPUT_RESULTS_FORMAT = 'geojson'
 
-SLOW_TEST_TIMEOUT_SECONDS = 3000 # seconds = 50 minutes (Duration needed for fractional vegetation)
+SLOW_TEST_TIMEOUT_SECONDS = 3600 # seconds = 1 hour (Duration needed for fractional vegetation)
 
 
 @timeout_decorator.timeout(SLOW_TEST_TIMEOUT_SECONDS)
@@ -114,7 +114,7 @@ def test_write_NaturalAreasPercent(target_folder):
 
 @timeout_decorator.timeout(SLOW_TEST_TIMEOUT_SECONDS)
 @pytest.mark.skipif(DUMP_RUN_LEVEL != DumpRunLevel.RUN_FAST_ONLY, reason=f"Skipping since DUMP_RUN_LEVEL set to {DUMP_RUN_LEVEL}")
-def test_write_PercentAreaFracvegExceedsThreshold(target_folder):
+def test_write_PercentAreaFracVegExceedsThreshold(target_folder):
     metric_obj = PercentAreaFracvegExceedsThreshold()
     _run_write_metrics_by_city_test(metric_obj, target_folder, GEOEXTENT_TERESINA, GEOZONE_TERESINA)
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -18,7 +18,7 @@ BBOX = BBOX_USA_OR_PORTLAND_2
 def test_acag_pm2p5():
     data = AcagPM2p5().get_data(BBOX)
     assert np.size(data) > 0
-    assert_raster_stats(data, 2, 6.18, 6.18, 1, 0)
+    assert_raster_stats(data, 2, 5.89, 6.53, 9797, 0)
     assert get_projection_type(data.crs) == ProjectionType.UTM
 
 def test_albedo_cloud_masked():

--- a/tests/test_metrics_per_city.py
+++ b/tests/test_metrics_per_city.py
@@ -8,11 +8,10 @@ def test_city_values_BuiltLandWithHighLST():
     metric_values = metric_obj.get_metric(geo_zone=GEOZONE_TERESINA)
     _evaluate_metric_values(metric_values, 2, 0, 0.11, 0.03, 138, 10, True)
 
-# TODO The current specified value for continuity should be true, but specified here as False so the test passes. Count is also wrong.
 def test_city_values_mean_pm2p5_exposure():
     metric_obj = MeanPM2P5Exposure()
     metric_values = metric_obj.get_metric(geo_zone=GEOZONE_TERESINA)
-    _evaluate_metric_values(metric_values, 2, 11.13, 14.09, 12.4, 107, 0, False)
+    _evaluate_metric_values(metric_values, 2, 11.18, 14.04, 12.45, 138, 0, True)
 
 def test_city_values_NaturalAreasPercent():
     metric_obj = NaturalAreasPercent()


### PR DESCRIPTION
Changed default resolution of AcagPM2p5 to improve odds of including values in city admin polygons. 
Modified to handle empty aggrregated_data for raster layers.

See https://gfw.atlassian.net/browse/CDB-393 

Example output: s3://wri-cities-sandbox/kennc/metrics_for_teresina_2025_07_01.zip