### PR TITLE
Pin geemap==0.36.0rc2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "earthengine-api",
         "geocube",
         "odc-stac",
-        "geemap>=0.35.2",
+        "geemap==0.36.0rc2",
         "pystac-client",
         "xarray",
         "xarray-spatial",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "earthengine-api",
         "geocube",
         "odc-stac",
-        "geemap==0.36.0rc2",
+        "geemap>=0.36.0",
         "pystac-client",
         "xarray",
         "xarray-spatial",


### PR DESCRIPTION
Ran into this error
```
File "/opt/homebrew/Caskroom/miniconda/base/envs/open-urban/lib/python3.13/site-packages/city_metrix/layers/open_buildings.py", line 2, in <module>
import geemap
File "/opt/homebrew/Caskroom/miniconda/base/envs/open-urban/lib/python3.13/site-packages/geemap/init.py", line 55, in <module>
raise e
File "/opt/homebrew/Caskroom/miniconda/base/envs/open-urban/lib/python3.13/site-packages/geemap/init.py", line 45, in <module>
from .geemap import *
File "/opt/homebrew/Caskroom/miniconda/base/envs/open-urban/lib/python3.13/site-packages/geemap/geemap.py", line 28, in <module>
from .conversion import *
File "/opt/homebrew/Caskroom/miniconda/base/envs/open-urban/lib/python3.13/site-packages/geemap/conversion.py", line 23, in <module>
import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Based on https://github.com/gee-community/geemap/issues/2274 I tried installing https://pypi.org/project/geemap/0.36.0rc2/ which seemed to fix the issue.