### PR TITLE
add osm class for subway station access points

### DIFF
--- a/city_metrix/layers/open_street_map.py
+++ b/city_metrix/layers/open_street_map.py
@@ -82,6 +82,10 @@ class OpenStreetMapClass(Enum):
                                    'school': True}
     HIGHER_EDUCATION = {'amenity': ['college', 'university', 'research_institute'],
                         'building': ['college', 'university']}
+    SUBWAY_STATION = {
+                      'railway': ['subway_entrance'],
+                    #   'station': ['subway']  This tag is supposed to be for center of station, not access points
+                      }
     TRANSIT_STOP = {'amenity': ['ferry_terminal'],
                     'railway': ['stop', 'platform', 'halt', 'tram_stop', 'subway_entrance', 'station'],
                     'highway': ['bus_stop', 'platform'],


### PR DESCRIPTION
Adds OSM class for subway stations. Uses `railway: subway_entrance`, which seems to capture well entrance points to subway stations. Note that another tag, `station: subway` exists for the center of the subway station. For Chengdu, at least, this tag does not capture aboveground access points.