### PR TITLE
Feat option for versions for world pop

### DIFF
--- a/city_metrix/layers/albedo_cloud_masked.py
+++ b/city_metrix/layers/albedo_cloud_masked.py
@@ -22,7 +22,7 @@ DEFAULT_RESAMPLING_METHOD = "bilinear"
 class AlbedoCloudMasked(Layer):
     OUTPUT_FILE_FORMAT = GTIFF_FILE_EXTENSION
     MAJOR_NAMING_ATTS = ["zonal_stats", "num_seasons", "start_date", "end_date"]
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["worldpop_version"]
     PROCESSING_TILE_SIDE_M = 5000
 
     """

--- a/city_metrix/layers/albedo_cloud_masked.py
+++ b/city_metrix/layers/albedo_cloud_masked.py
@@ -32,13 +32,14 @@ class AlbedoCloudMasked(Layer):
         zonal_stats: use 'mean' or 'median' for albedo zonal stats
     """
 
-    def __init__(self, start_date:str=None, end_date:str=None, index_aggregation=False, zonal_stats='median', num_seasons=3, **kwargs):
+    def __init__(self, start_date:str=None, end_date:str=None, index_aggregation=False, zonal_stats='median', num_seasons=3, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.start_date = start_date
         self.end_date = end_date
         self.zonal_stats = zonal_stats
         self.index_aggregation = index_aggregation
         self.num_seasons = num_seasons
+        self.worldpop_version = worldpop_version
         
     def get_masked_s2_collection(self, bbox_ee, start_date, end_date):
         CLEAR_THRESHOLD = 0.60
@@ -146,6 +147,6 @@ class AlbedoCloudMasked(Layer):
         # Trim back to original AOI
         result_data = extract_bbox_aoi(result_data, bbox)
         if self.index_aggregation:
-            wp_array =  WorldPop().get_data(bbox)
+            wp_array =  WorldPop(version=self.worldpop_version).get_data(bbox)
             return align_raster_array(data, wp_array)
         return result_data

--- a/city_metrix/layers/fractional_vegetation_percent.py
+++ b/city_metrix/layers/fractional_vegetation_percent.py
@@ -17,11 +17,12 @@ class FractionalVegetationPercent(Layer):
     MAJOR_NAMING_ATTS = ["min_threshold"]
     MINOR_NAMING_ATTS = None
 
-    def __init__(self, min_threshold=None, year=2025, index_aggregation=False, **kwargs):
+    def __init__(self, min_threshold=None, year=2025, index_aggregation=False, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.min_threshold = min_threshold
         self.year = year
         self.index_aggregation = index_aggregation
+        self.worldpop_version = worldpop_version
 
 
     def get_data(self, bbox: GeoExtent, spatial_resolution: int = DEFAULT_SPATIAL_RESOLUTION,
@@ -188,6 +189,6 @@ class FractionalVegetationPercent(Layer):
                 data = xr.where(data >= self.min_threshold, 1, np.nan).rio.write_crs(bbox.as_utm_bbox().crs, inplace=True)
 
         if self.index_aggregation:
-            wp_array =  WorldPop().get_data(bbox)
+            wp_array =  WorldPop(version=self.worldpop_version).get_data(bbox)
             return align_raster_array(data, wp_array)
         return data

--- a/city_metrix/layers/fractional_vegetation_percent.py
+++ b/city_metrix/layers/fractional_vegetation_percent.py
@@ -15,7 +15,7 @@ class FractionalVegetationPercent(Layer):
     OUTPUT_FILE_FORMAT = GTIFF_FILE_EXTENSION
     PROCESSING_TILE_SIDE_M = 5000
     MAJOR_NAMING_ATTS = ["min_threshold"]
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["worldpop_version"]
 
     def __init__(self, min_threshold=None, year=2025, index_aggregation=False, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)

--- a/city_metrix/layers/high_land_surface_temperature.py
+++ b/city_metrix/layers/high_land_surface_temperature.py
@@ -24,13 +24,14 @@ class HighLandSurfaceTemperature(Layer):
         start_date: starting date for data retrieval
         end_date: ending date for data retrieval
     """
-    def __init__(self, start_date="2023-01-01", end_date="2026-01-01", index_aggregation=False, high_lst=False, use_modis=False, **kwargs):
+    def __init__(self, start_date="2023-01-01", end_date="2026-01-01", index_aggregation=False, high_lst=False, use_modis=False, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.start_date = start_date
         self.end_date = end_date
         self.index_aggregation = index_aggregation
         self.high_lst = high_lst
         self.use_modis = use_modis
+        self.worldpop_version = worldpop_version
 
     def get_data(self, bbox: GeoExtent, spatial_resolution:int=DEFAULT_SPATIAL_RESOLUTION_LANDSAT,
                  resampling_method=None):
@@ -51,6 +52,6 @@ class HighLandSurfaceTemperature(Layer):
         else:
             lst_array = lst
         if self.index_aggregation:
-            wp_array =  WorldPop().get_data(bbox)
+            wp_array =  WorldPop(version=self.worldpop_version).get_data(bbox)
             lst_array = align_raster_array(lst_array, wp_array)
         return lst_array

--- a/city_metrix/layers/high_land_surface_temperature.py
+++ b/city_metrix/layers/high_land_surface_temperature.py
@@ -16,7 +16,7 @@ HOT_SEASON_LENGTH = 90
 class HighLandSurfaceTemperature(Layer):
     OUTPUT_FILE_FORMAT = GTIFF_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["worldpop_version"]
     THRESHOLD_ADD = 3
 
     """

--- a/city_metrix/layers/key_biodiversity_areas.py
+++ b/city_metrix/layers/key_biodiversity_areas.py
@@ -36,9 +36,10 @@ class KeyBiodiversityAreas(Layer):
         country_code_iso3 must be one of the countries currently supported in Cities Data (plus USA for testing)
     """
 
-    def __init__(self, country_code_iso3=None, **kwargs):
+    def __init__(self, country_code_iso3=None, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.country_code_iso3 = country_code_iso3
+        self.worldpop_version = worldpop_version
 
     def get_data(self, bbox: GeoExtent, spatial_resolution=None, resampling_method=None,
                  force_data_refresh=False):
@@ -57,7 +58,7 @@ class KeyBiodiversityAreas(Layer):
         country_kba_data = GeoDataFrame.from_file(f'{AWS_STEM}/{S3_KBA_PREFIX}/KBA_{country_code}.geojson')
         city_kba_data = country_kba_data.loc[country_kba_data.intersects(bbox.as_geographic_bbox().polygon)]
 
-        worldpop_data = WorldPop().get_data(bbox)
+        worldpop_data = WorldPop(version=self.worldpop_version).get_data(bbox)
         if len(city_kba_data) > 0:
             dissolved_kba_data = city_kba_data.dissolve()
             data = GeoDataFrame({'id': [0], 'is_kba': 1, 'geometry': dissolved_kba_data.geometry}).to_crs(utm_crs)

--- a/city_metrix/layers/key_biodiversity_areas.py
+++ b/city_metrix/layers/key_biodiversity_areas.py
@@ -29,7 +29,7 @@ def _rasterize(gdf, snap_to):
 class KeyBiodiversityAreas(Layer):
     OUTPUT_FILE_FORMAT = GTIFF_FILE_EXTENSION
     MAJOR_NAMING_ATTS = ['country_code_iso3']
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["worldpop_version"]
 
     """
     Attributes:

--- a/city_metrix/layers/open_street_map.py
+++ b/city_metrix/layers/open_street_map.py
@@ -99,7 +99,7 @@ class OpenStreetMapClass(Enum):
 class OpenStreetMap(Layer):
     OUTPUT_FILE_FORMAT = GEOJSON_FILE_EXTENSION
     MAJOR_NAMING_ATTS = ["osm_class"]
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["worldpop_version"]
 
     """
     Attributes:

--- a/city_metrix/layers/open_street_map.py
+++ b/city_metrix/layers/open_street_map.py
@@ -106,9 +106,10 @@ class OpenStreetMap(Layer):
         osm_class: OSM class
     """
 
-    def __init__(self, osm_class: OpenStreetMapClass = OpenStreetMapClass.ALL, **kwargs):
+    def __init__(self, osm_class: OpenStreetMapClass=OpenStreetMapClass.ALL, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.osm_class = osm_class
+        self.worldpop_version = worldpop_version
 
     def get_data(self, bbox: GeoExtent, spatial_resolution=None, resampling_method=None,
                  force_data_refresh=False):
@@ -190,9 +191,10 @@ class OpenStreetMapAmenityCount(Layer):
         osm_class: OSM class
     """
 
-    def __init__(self, osm_class: OpenStreetMapClass = OpenStreetMapClass.ALL, **kwargs):
+    def __init__(self, osm_class: OpenStreetMapClass = OpenStreetMapClass.ALL, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.osm_class = osm_class
+        self.worldpop_version = worldpop_version
 
     def get_data(self, bbox: GeoExtent, spatial_resolution=None, resampling_method=None,
                  force_data_refresh=False):
@@ -209,7 +211,7 @@ class OpenStreetMapAmenityCount(Layer):
         )
 
         # Get Worldpop raster for grid template
-        worldpop_ras = WorldPop().get_data(bbox)
+        worldpop_ras = WorldPop(version=self.worldpop_version).get_data(bbox)
 
         amenities_ras = _rasterize_gdf(
             amenities_gdf, worldpop_ras, "amenitycount")

--- a/city_metrix/layers/pop_weighted_pm2p5.py
+++ b/city_metrix/layers/pop_weighted_pm2p5.py
@@ -10,7 +10,7 @@ DEFAULT_SPATIAL_RESOLUTION = 100
 class PopWeightedPM2p5(Layer):
     OUTPUT_FILE_FORMAT = GTIFF_FILE_EXTENSION
     MAJOR_NAMING_ATTS = ["worldpop_agesex_classes"]
-    MINOR_NAMING_ATTS = ["worldpop_year", "acag_year", "acag_return_above"]
+    MINOR_NAMING_ATTS = ["worldpop_year", "acag_year", "acag_return_above", "worldpop_version"]
 
     """
     Attributes:

--- a/city_metrix/layers/pop_weighted_pm2p5.py
+++ b/city_metrix/layers/pop_weighted_pm2p5.py
@@ -22,10 +22,11 @@ class PopWeightedPM2p5(Layer):
     """
     # get_data() for this class returns DataArray with pm2.5 concentration multiplied by (pixelpop/meanpop)
 
-    def __init__(self, worldpop_agesex_classes:WorldPopClass=[], worldpop_year=2020, acag_year=2023, acag_return_above=0, **kwargs):
+    def __init__(self, worldpop_agesex_classes:WorldPopClass=[], worldpop_year=2020, worldpop_version=1, acag_year=2023, acag_return_above=0, **kwargs):
         super().__init__(**kwargs)
         self.worldpop_agesex_classes = worldpop_agesex_classes
         self.worldpop_year = worldpop_year
+        self.worldpop_version = worldpop_version
         self.acag_year = acag_year
         self.acag_return_above = acag_return_above
 
@@ -36,7 +37,7 @@ class PopWeightedPM2p5(Layer):
         # spatial_resolution = DEFAULT_SPATIAL_RESOLUTION if spatial_resolution is None else spatial_resolution
         spatial_resolution = self.resolution or spatial_resolution or DEFAULT_SPATIAL_RESOLUTION
 
-        world_pop = (WorldPop(agesex_classes=self.worldpop_agesex_classes, year=self.worldpop_year)
+        world_pop = (WorldPop(agesex_classes=self.worldpop_agesex_classes, year=self.worldpop_year, version=self.worldpop_version)
                      .get_data(bbox, spatial_resolution=spatial_resolution))
         pm2p5 = (AcagPM2p5(year=self.acag_year, return_above=self.acag_return_above)
                  .get_data(bbox, spatial_resolution=spatial_resolution))

--- a/city_metrix/layers/tree_canopy_height.py
+++ b/city_metrix/layers/tree_canopy_height.py
@@ -19,11 +19,10 @@ class TreeCanopyHeight(Layer):
     Attributes:
         height: minimum tree height used for filtering results
     """
-    def __init__(self, height=None, index_aggregation=False, version=2, worldpop_version=1, **kwargs):
+    def __init__(self, height=None, index_aggregation=False, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.index_aggregation = index_aggregation
-        self.version = version
         self.worldpop_version = worldpop_version
 
     def get_data(self, bbox: GeoExtent, spatial_resolution:int=DEFAULT_SPATIAL_RESOLUTION,

--- a/city_metrix/layers/tree_canopy_height.py
+++ b/city_metrix/layers/tree_canopy_height.py
@@ -19,10 +19,11 @@ class TreeCanopyHeight(Layer):
     Attributes:
         height: minimum tree height used for filtering results
     """
-    def __init__(self, height=None, index_aggregation=False, **kwargs):
+    def __init__(self, height=None, index_aggregation=False, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.index_aggregation = index_aggregation
+        self.worldpop_version = worldpop_version
 
     def get_data(self, bbox: GeoExtent, spatial_resolution:int=DEFAULT_SPATIAL_RESOLUTION,
                  resampling_method=None):
@@ -58,6 +59,6 @@ class TreeCanopyHeight(Layer):
         result_data = result_data.rio.write_crs(utm_crs)
         result_data['crs'] = utm_crs
         if self.index_aggregation:
-            wp_array =  WorldPop().get_data(bbox)
+            wp_array =  WorldPop(version=self.worldpop_version).get_data(bbox)
             return align_raster_array(data, wp_array)
         return result_data

--- a/city_metrix/layers/tree_canopy_height.py
+++ b/city_metrix/layers/tree_canopy_height.py
@@ -36,13 +36,8 @@ class TreeCanopyHeight(Layer):
         buffered_utm_bbox = bbox.buffer_utm_bbox(10)
         ee_rectangle  = buffered_utm_bbox.to_ee_rectangle()
 
-        if self.version == 1:
-            canopy_ht = ee.ImageCollection("projects/meta-forest-monitoring-okw37/assets/CanopyHeight")
-        elif self.version == 2:   
-            canopy_ht = ee.ImageCollection("projects/sat-io/open-datasets/facebook/meta-canopy-height");
-        else:
-            raise Exception (f"Tree Canopy Height version {self.version} not supported")
-
+        canopy_ht = ee.ImageCollection("projects/meta-forest-monitoring-okw37/assets/CanopyHeight")
+        
         # aggregate time series into a single image
         canopy_ht_img = (canopy_ht
                          .reduce(ee.Reducer.mean())

--- a/city_metrix/layers/tree_canopy_height.py
+++ b/city_metrix/layers/tree_canopy_height.py
@@ -12,17 +12,18 @@ class TreeCanopyHeight(Layer):
     OUTPUT_FILE_FORMAT = GTIFF_FILE_EXTENSION
     PROCESSING_TILE_SIDE_M = 5000
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = ["height"]
+    MINOR_NAMING_ATTS = ["height", "worldpop_version"]
     NO_DATA_VALUE = 0
 
     """
     Attributes:
         height: minimum tree height used for filtering results
     """
-    def __init__(self, height=None, index_aggregation=False, worldpop_version=1, **kwargs):
+    def __init__(self, height=None, index_aggregation=False, version=2, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.index_aggregation = index_aggregation
+        self.version = version
         self.worldpop_version = worldpop_version
 
     def get_data(self, bbox: GeoExtent, spatial_resolution:int=DEFAULT_SPATIAL_RESOLUTION,
@@ -35,7 +36,12 @@ class TreeCanopyHeight(Layer):
         buffered_utm_bbox = bbox.buffer_utm_bbox(10)
         ee_rectangle  = buffered_utm_bbox.to_ee_rectangle()
 
-        canopy_ht = ee.ImageCollection("projects/meta-forest-monitoring-okw37/assets/CanopyHeight")
+        if self.version == 1:
+            canopy_ht = ee.ImageCollection("projects/meta-forest-monitoring-okw37/assets/CanopyHeight")
+        elif self.version == 2:   
+            canopy_ht = ee.ImageCollection("projects/sat-io/open-datasets/facebook/meta-canopy-height");
+        else:
+            raise Exception (f"Tree Canopy Height version {self.version} not supported")
 
         # aggregate time series into a single image
         canopy_ht_img = (canopy_ht

--- a/city_metrix/layers/tree_canopy_height_for_ctcm.py
+++ b/city_metrix/layers/tree_canopy_height_for_ctcm.py
@@ -18,10 +18,9 @@ class TreeCanopyHeightCTCM(Layer):
     Attributes:
         height: minimum tree height used for filtering results
     """
-    def __init__(self, height=None, version=2, **kwargs):
+    def __init__(self, height=None, **kwargs):
         super().__init__(**kwargs)
         self.height = height
-        self.version = version
 
     def get_data(self, bbox: GeoExtent, spatial_resolution:int=DEFAULT_SPATIAL_RESOLUTION,
                  resampling_method=None):

--- a/city_metrix/layers/tree_canopy_height_for_ctcm.py
+++ b/city_metrix/layers/tree_canopy_height_for_ctcm.py
@@ -18,9 +18,10 @@ class TreeCanopyHeightCTCM(Layer):
     Attributes:
         height: minimum tree height used for filtering results
     """
-    def __init__(self, height=None, **kwargs):
+    def __init__(self, height=None, version=2, **kwargs):
         super().__init__(**kwargs)
         self.height = height
+        self.version = version
 
     def get_data(self, bbox: GeoExtent, spatial_resolution:int=DEFAULT_SPATIAL_RESOLUTION,
                  resampling_method=None):
@@ -32,7 +33,12 @@ class TreeCanopyHeightCTCM(Layer):
         buffered_utm_bbox = bbox.buffer_utm_bbox(10)
         ee_rectangle  = buffered_utm_bbox.to_ee_rectangle()
 
-        canopy_ht = ee.ImageCollection("projects/meta-forest-monitoring-okw37/assets/CanopyHeight")
+        if self.version == 1:
+            canopy_ht = ee.ImageCollection("projects/meta-forest-monitoring-okw37/assets/CanopyHeight")
+        elif self.version == 2:   
+            canopy_ht = ee.ImageCollection("projects/sat-io/open-datasets/facebook/meta-canopy-height");
+        else:
+            raise Exception (f"Tree Canopy Height version {self.version} not supported")
 
         # aggregate time series into a single image
         canopy_ht_img = (canopy_ht

--- a/city_metrix/layers/tree_canopy_height_for_ctcm.py
+++ b/city_metrix/layers/tree_canopy_height_for_ctcm.py
@@ -33,13 +33,8 @@ class TreeCanopyHeightCTCM(Layer):
         buffered_utm_bbox = bbox.buffer_utm_bbox(10)
         ee_rectangle  = buffered_utm_bbox.to_ee_rectangle()
 
-        if self.version == 1:
-            canopy_ht = ee.ImageCollection("projects/meta-forest-monitoring-okw37/assets/CanopyHeight")
-        elif self.version == 2:   
-            canopy_ht = ee.ImageCollection("projects/sat-io/open-datasets/facebook/meta-canopy-height");
-        else:
-            raise Exception (f"Tree Canopy Height version {self.version} not supported")
-
+        canopy_ht = ee.ImageCollection("projects/meta-forest-monitoring-okw37/assets/CanopyHeight")
+        
         # aggregate time series into a single image
         canopy_ht_img = (canopy_ht
                          .reduce(ee.Reducer.mean())

--- a/city_metrix/layers/world_pop.py
+++ b/city_metrix/layers/world_pop.py
@@ -37,7 +37,7 @@ class WorldPop(Layer):
         # F_0, F_1, F_5, F_10, F_15, F_20, F_25, F_30, F_35, F_40, F_45, F_50, F_55, F_60, F_65, F_70, F_75, F_80
         self.agesex_classes = agesex_classes
         self.version=version
-        self.year = year
+        self.year = year if version==1 else str(year)
 
     def get_data(self, bbox: GeoExtent, spatial_resolution:int=DEFAULT_SPATIAL_RESOLUTION,
                  resampling_method=None):

--- a/city_metrix/layers/world_pop.py
+++ b/city_metrix/layers/world_pop.py
@@ -9,6 +9,8 @@ from ..constants import GTIFF_FILE_EXTENSION
 DEFAULT_SPATIAL_RESOLUTION = 100
 
 class WorldPopClass(Enum):
+    ADULT = ['F_20', 'F_25', 'F_30', 'F_35', 'F_40', 'F_45', 'F_50', 'F_55', 'F_60', 'F_65', 'F_70', 'F_75', 'F_80',
+            'M_20', 'M_25', 'M_30', 'M_35', 'M_40', 'M_45', 'M_50', 'M_55', 'M_60', 'M_65', 'M_70', 'M_75', 'M_80']
     ELDERLY = ['F_60', 'F_65', 'F_70', 'F_75', 'F_80',
                'M_60', 'M_65', 'M_70', 'M_75', 'M_80']
     CHILDREN = ['F_0', 'F_1', 'F_5', 'F_10', 'M_0', 'M_1', 'M_5', 'M_10']
@@ -28,12 +30,13 @@ class WorldPop(Layer):
                         list of age-sex classes to retrieve (see https://airtable.com/appDWCVIQlVnLLaW2/tblYpXsxxuaOk3PaZ/viwExxAgTQKZnRfWU/recFjH7WngjltFMGi?blocks=hide)
         year: year used for data retrieval
     """
-    def __init__(self, agesex_classes:WorldPopClass=[], year=2020, **kwargs):
+    def __init__(self, agesex_classes:WorldPopClass=[], version=1, year=2020, **kwargs):
         super().__init__(**kwargs)
         # agesex_classes options:
         # M_0, M_1, M_5, M_10, M_15, M_20, M_25, M_30, M_35, M_40, M_45, M_50, M_55, M_60, M_65, M_70, M_75, M_80
         # F_0, F_1, F_5, F_10, F_15, F_20, F_25, F_30, F_35, F_40, F_45, F_50, F_55, F_60, F_65, F_70, F_75, F_80
         self.agesex_classes = agesex_classes
+        self.version=version
         self.year = year
 
     def get_data(self, bbox: GeoExtent, spatial_resolution:int=DEFAULT_SPATIAL_RESOLUTION,
@@ -44,7 +47,12 @@ class WorldPop(Layer):
         ee_rectangle = bbox.to_ee_rectangle()
         if not self.agesex_classes:
             # total population
-            dataset = ee.ImageCollection('WorldPop/GP/100m/pop')
+            if self.version == 1:
+                dataset = ee.ImageCollection('WorldPop/GP/100m/pop')
+            elif self.version == 2:
+                dataset = ee.ImageCollection('projects/sat-io/open-datasets/WORLDPOP/pop')
+            else:
+                raise Exception(f"WorldPop version {self.version} not supported") 
 
             world_pop_ic = ee.ImageCollection(
                 dataset
@@ -63,7 +71,12 @@ class WorldPop(Layer):
 
         else:
             # sum population for selected age-sex groups
-            world_pop_age_sex = ee.ImageCollection('WorldPop/GP/100m/pop_age_sex')
+            if self.version == 1:
+                world_pop_age_sex = ee.ImageCollection('WorldPop/GP/100m/pop_age_sex')
+            elif self.version == 2:
+                world_pop_age_sex = ee.ImageCollection('projects/sat-io/open-datasets/WORLDPOP/agesex')
+            else:
+                raise Exception(f"WorldPop version {self.version} not supported") 
 
             if isinstance(self.agesex_classes, WorldPopClass):
                 agesex_value = self.agesex_classes.value

--- a/city_metrix/layers/world_pop.py
+++ b/city_metrix/layers/world_pop.py
@@ -22,7 +22,7 @@ class WorldPopClass(Enum):
 class WorldPop(Layer):
     OUTPUT_FILE_FORMAT = GTIFF_FILE_EXTENSION
     MAJOR_NAMING_ATTS = ["agesex_classes"]
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["version"]
 
     """
     Attributes:

--- a/city_metrix/metrics/canopy_area_per_resident.py
+++ b/city_metrix/metrics/canopy_area_per_resident.py
@@ -11,7 +11,7 @@ class CanopyAreaPerResident__SquareMeters(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     CUSTOM_TILE_SIDE_M = 5000
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = ["height", "agesex_classes", "informal_only"]
+    MINOR_NAMING_ATTS = ["height", "agesex_classes", "informal_only", "worldpop_version"]
 
     def __init__(self,
                  agesex_classes=[],
@@ -62,18 +62,20 @@ class CanopyAreaPerResident__SquareMeters(Metric):
 class CanopyAreaPerResidentChildren__SquareMeters(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = ["height"]
+    MINOR_NAMING_ATTS = ["height", "worldpop_version"]
 
-    def __init__(self, height=3, year=2025, **kwargs):
+    def __init__(self, height=3, year=2025, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.year = year
         self.unit = 'square meters'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self,
                    geo_zone: GeoZone,
                    spatial_resolution: int = None) -> Union[pd.DataFrame | pd.Series]:
         return (CanopyAreaPerResident__SquareMeters(WorldPopClass.CHILDREN,
+                                                    self.worldop_version,
                                                     self.height,
                                                     False)
                 .get_metric(geo_zone))
@@ -82,18 +84,20 @@ class CanopyAreaPerResidentChildren__SquareMeters(Metric):
 class CanopyAreaPerResidentElderly__SquareMeters(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = ["height"]
+    MINOR_NAMING_ATTS = ["height", "worldpop_version"]
 
-    def __init__(self, height=3, year=2025, **kwargs):
+    def __init__(self, height=3, year=2025, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.year = year
         self.unit = 'square meters'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self,
                    geo_zone: GeoZone,
                    spatial_resolution: int = None) -> Union[pd.DataFrame | pd.Series]:
         return (CanopyAreaPerResident__SquareMeters(WorldPopClass.ELDERLY,
+                                                    self.worldpop_version,
                                                     self.height,
                                                     False)
                 .get_metric(geo_zone))
@@ -102,18 +106,20 @@ class CanopyAreaPerResidentElderly__SquareMeters(Metric):
 class CanopyAreaPerResidentFemale__SquareMeters(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = ["height"]
+    MINOR_NAMING_ATTS = ["height", "worldpop_version"]
 
-    def __init__(self, height=3, year=2025, **kwargs):
+    def __init__(self, height=3, year=2025, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.year=year
         self.unit = 'square meters'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self,
                    geo_zone: GeoZone,
                    spatial_resolution: int = None) -> Union[pd.DataFrame | pd.Series]:
         return (CanopyAreaPerResident__SquareMeters(WorldPopClass.FEMALE,
+                                                    self.worldpop_version,
                                                     self.height,
                                                     False)
                 .get_metric(geo_zone))
@@ -122,18 +128,20 @@ class CanopyAreaPerResidentFemale__SquareMeters(Metric):
 class CanopyAreaPerResidentInformal__SquareMeters(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = ["height"]
+    MINOR_NAMING_ATTS = ["height", "worldpop_version"]
 
     def __init__(self, height=3, year=2025, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.year = year
         self.unit = 'square meters'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self,
                    geo_zone: GeoZone,
                    spatial_resolution: int = None) -> Union[pd.DataFrame | pd.Series]:
         return (CanopyAreaPerResident__SquareMeters([],
+                                                    self.worldpop_version,
                                                     self.height,
                                                     True)
                 .get_metric(geo_zone))

--- a/city_metrix/metrics/canopy_area_per_resident.py
+++ b/city_metrix/metrics/canopy_area_per_resident.py
@@ -15,12 +15,14 @@ class CanopyAreaPerResident__SquareMeters(Metric):
 
     def __init__(self,
                  agesex_classes=[],
+                 worldpop_version=1,
                  height=3,
                  informal_only=False,
                  year=2025,
                  **kwargs):
         super().__init__(**kwargs)
         self.agesex_classes = agesex_classes
+        self.worldpop_version = worldpop_version
         self.height = height
         self.informal_only = informal_only
         self.year = year
@@ -30,7 +32,7 @@ class CanopyAreaPerResident__SquareMeters(Metric):
                    geo_zone: GeoZone,
                    spatial_resolution: int = None) -> Union[pd.DataFrame | pd.Series]:
 
-        world_pop = WorldPop(agesex_classes=self.agesex_classes)
+        world_pop = WorldPop(agesex_classes=self.agesex_classes, version=self.worldpop_version)
         # tree canopy height has default spatial resolution of 1, count equals area
         tree_canopy_height = TreeCanopyHeight(height=self.height)
 

--- a/city_metrix/metrics/canopy_covered_population.py
+++ b/city_metrix/metrics/canopy_covered_population.py
@@ -133,7 +133,7 @@ class CanopyCoveredPopulationFemale__Percent(Metric):
 class CanopyCoveredPopulationInformal__Percent(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = ["height", "percentage"]
+    MINOR_NAMING_ATTS = ["height", "percentage", "worldpop_version"]
 
     def __init__(self, height=3, percentage=30, year=2025, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)

--- a/city_metrix/metrics/canopy_covered_population.py
+++ b/city_metrix/metrics/canopy_covered_population.py
@@ -17,10 +17,11 @@ class CanopyCoveredPopulation__Percent(Metric):
     MINOR_NAMING_ATTS = ["worldpop_agesex_classes", "height", "informal_only"]
 
     def __init__(
-        self, worldpop_agesex_classes=[], height=3, percentage=30, informal_only=False, year=2025, **kwargs
+        self, worldpop_agesex_classes=[], worldpop_version=1,  height=3, percentage=30, informal_only=False, year=2025, **kwargs
     ):
         super().__init__(**kwargs)
         self.worldpop_agesex_classes = worldpop_agesex_classes
+        self.worldpop_version = worldpop_version
         self.height = height
         self.percentage = percentage
         self.informal_only = informal_only
@@ -34,13 +35,13 @@ class CanopyCoveredPopulation__Percent(Metric):
         if self.informal_only:
             # urban land use class 3 for Informal
             urban_land_use = UrbanLandUse(ulu_class=3)
-            pop_layer = WorldPop(agesex_classes=self.worldpop_agesex_classes, masks=[urban_land_use, coverage_mask])
+            pop_layer = WorldPop(agesex_classes=self.worldpop_agesex_classes, masks=[urban_land_use, coverage_mask], version=self.worldpop_version)
 
         else:
-            pop_layer = WorldPop(agesex_classes=self.worldpop_agesex_classes, masks=[coverage_mask])
+            pop_layer = WorldPop(agesex_classes=self.worldpop_agesex_classes, masks=[coverage_mask], version=self.worldpop_version)
 
         access_pop = pop_layer.groupby(geo_zone).sum()
-        total_pop = WorldPop(agesex_classes=self.worldpop_agesex_classes).groupby(geo_zone).sum()
+        total_pop = WorldPop(agesex_classes=self.worldpop_agesex_classes, version=self.woldpop_version).groupby(geo_zone).sum()
 
         if not isinstance(access_pop, (int, float)):
             access_pop = access_pop.fillna(0)
@@ -59,19 +60,21 @@ class CanopyCoveredPopulationChildren__Percent(Metric):
     MAJOR_NAMING_ATTS = None
     MINOR_NAMING_ATTS = ["height", "percentage"]
 
-    def __init__(self, height=3, percentage=30, year=2025, **kwargs):
+    def __init__(self, height=3, percentage=30, year=2025, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.percentage = percentage
         self.year = year
         self.unit = 'percent'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self, geo_zone: GeoZone, spatial_resolution: int = None) -> Union[pd.DataFrame | pd.Series]:
         percent_canopy_covered_children = CanopyCoveredPopulation__Percent(
             worldpop_agesex_classes=WorldPopClass.CHILDREN,
+            worldpop_version=self.worldpop_version,
             height=self.height,
             percentage=self.percentage,
-            informal_only=False,
+            informal_only=False
         )
 
         return percent_canopy_covered_children.get_metric(geo_zone=geo_zone)
@@ -82,16 +85,18 @@ class CanopyCoveredPopulationElderly__Percent(Metric):
     MAJOR_NAMING_ATTS = None
     MINOR_NAMING_ATTS = ["height", "percentage"]
 
-    def __init__(self, height=3, percentage=30, year=2025, **kwargs):
+    def __init__(self, height=3, percentage=30, year=2025, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.percentage = percentage
         self.year = year
         self.unit = 'percent'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self, geo_zone: GeoZone, spatial_resolution: int = None) -> Union[pd.DataFrame | pd.Series]:
         percent_canopy_covered_elderly = CanopyCoveredPopulation__Percent(
             worldpop_agesex_classes=WorldPopClass.ELDERLY,
+            worldpop_version=self.worldpop_version,
             height=self.height,
             percentage=self.percentage,
             informal_only=False,
@@ -105,16 +110,18 @@ class CanopyCoveredPopulationFemale__Percent(Metric):
     MAJOR_NAMING_ATTS = None
     MINOR_NAMING_ATTS = ["height", "percentage"]
 
-    def __init__(self, height=3, percentage=30, year=2025, **kwargs):
+    def __init__(self, height=3, percentage=30, year=2025, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.percentage = percentage
         self.year = year
         self.unit = 'percent'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self, geo_zone: GeoZone, spatial_resolution: int = None) -> Union[pd.DataFrame | pd.Series]:
         percent_canopy_covered_female = CanopyCoveredPopulation__Percent(
             worldpop_agesex_classes=WorldPopClass.FEMALE,
+            worldpop_version=self.worldpop_version,
             height=self.height,
             percentage=self.percentage,
             informal_only=False,
@@ -128,16 +135,18 @@ class CanopyCoveredPopulationInformal__Percent(Metric):
     MAJOR_NAMING_ATTS = None
     MINOR_NAMING_ATTS = ["height", "percentage"]
 
-    def __init__(self, height=3, percentage=30, year=2025, **kwargs):
+    def __init__(self, height=3, percentage=30, year=2025, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.height = height
         self.percentage = percentage
         self.year = year
         self.unit = 'percent'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self, geo_zone: GeoZone, spatial_resolution: int = None) -> Union[pd.DataFrame | pd.Series]:
         percent_canopy_covered_informal = CanopyCoveredPopulation__Percent(
             worldpop_agesex_classes=[],
+            worldpop_version=self.worldpop_version,
             height=self.height,
             percentage=self.percentage,
             informal_only=True,

--- a/city_metrix/metrics/hospitals_per_ten_thousand_residents.py
+++ b/city_metrix/metrics/hospitals_per_ten_thousand_residents.py
@@ -10,7 +10,7 @@ from city_metrix.layers import OpenStreetMap, OpenStreetMapClass, WorldPop
 class HospitalsPerTenThousandResidents__Hospitals(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["worldpop_version"]
 
     def __init__(self, year=datetime.datetime.now().year, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)

--- a/city_metrix/metrics/hospitals_per_ten_thousand_residents.py
+++ b/city_metrix/metrics/hospitals_per_ten_thousand_residents.py
@@ -12,22 +12,23 @@ class HospitalsPerTenThousandResidents__Hospitals(Metric):
     MAJOR_NAMING_ATTS = None
     MINOR_NAMING_ATTS = None
 
-    def __init__(self, year=datetime.datetime.now().year, **kwargs):
+    def __init__(self, year=datetime.datetime.now().year, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.year = year
         self.unit = 'hospitals'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self,
                  geo_zone: GeoZone,
                  spatial_resolution:int = None) -> Union[pd.DataFrame | pd.Series]:
 
-        hospitals = OpenStreetMap(osm_class=OpenStreetMapClass.HOSPITAL).get_data(GeoExtent(geo_zone))
+        hospitals = OpenStreetMap(osm_class=OpenStreetMapClass.HOSPITAL, worldpop_version=self.worldpop_version).get_data(GeoExtent(geo_zone))
         hospital_counts_per_zone = [
                 hospitals.geometry.intersects(zone).sum()
                 for zone in geo_zone.zones.geometry
             ]
 
-        world_pop = WorldPop()
+        world_pop = WorldPop(version=self.worldpop_version)
         world_pop_sum = world_pop.groupby(geo_zone).sum()
 
         if isinstance(world_pop_sum, pd.DataFrame):

--- a/city_metrix/metrics/impervious_surface_on_urbanized_land.py
+++ b/city_metrix/metrics/impervious_surface_on_urbanized_land.py
@@ -9,7 +9,7 @@ from city_metrix.layers import UrbanExtents, ImperviousSurface, WorldPop
 class ImperviousSurfaceOnUrbanizedLand__Percent(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["worldpop_version"]
 
     def __init__(self, year=2015, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)

--- a/city_metrix/metrics/impervious_surface_on_urbanized_land.py
+++ b/city_metrix/metrics/impervious_surface_on_urbanized_land.py
@@ -11,10 +11,11 @@ class ImperviousSurfaceOnUrbanizedLand__Percent(Metric):
     MAJOR_NAMING_ATTS = None
     MINOR_NAMING_ATTS = None
 
-    def __init__(self, year=2015, **kwargs):
+    def __init__(self, year=2015, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.year = year
         self.unit = 'percent'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self,
                    geo_zone: GeoZone,
@@ -22,7 +23,7 @@ class ImperviousSurfaceOnUrbanizedLand__Percent(Metric):
 
         impervious_layer = ImperviousSurface(year=self.year)
         urban_layer = UrbanExtents()
-        area_layer = WorldPop()
+        area_layer = WorldPop(version=self.worldpop_vesion)
 
         impervious_area = area_layer.mask(urban_layer).mask(impervious_layer).groupby(geo_zone).count()
         urban_area = area_layer.mask(urban_layer).groupby(geo_zone).count()

--- a/city_metrix/metrics/key_biodiversity_area.py
+++ b/city_metrix/metrics/key_biodiversity_area.py
@@ -40,7 +40,7 @@ def _resolve_country_iso3(geo_zone: GeoZone, country_code_iso3: Optional[str]) -
 class KeyBiodiversityAreaProtected__Percent(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["worldpop_version"]
 
     def __init__(self, country_code_iso3=None, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
@@ -76,7 +76,7 @@ class KeyBiodiversityAreaProtected__Percent(Metric):
 class KeyBiodiversityAreaUndeveloped__Percent(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["worldpop_version"]
 
     def __init__(self, country_code_iso3=None, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)

--- a/city_metrix/metrics/key_biodiversity_area.py
+++ b/city_metrix/metrics/key_biodiversity_area.py
@@ -42,16 +42,17 @@ class KeyBiodiversityAreaProtected__Percent(Metric):
     MAJOR_NAMING_ATTS = None
     MINOR_NAMING_ATTS = None
 
-    def __init__(self, country_code_iso3=None, **kwargs):
+    def __init__(self, country_code_iso3=None, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.country_code_iso3 = country_code_iso3
+        self.worldpop_version = worldpop_version
 
     def get_metric(self,
                    geo_zone: GeoZone,
                    spatial_resolution: int = None) -> Union[pd.DataFrame, pd.Series]:
         country_code_iso3 = _resolve_country_iso3(geo_zone, self.country_code_iso3)
 
-        worldpop_layer = WorldPop()
+        worldpop_layer = WorldPop(version=self.worldpop_version)
         kba_layer = KeyBiodiversityAreas(country_code_iso3)
         protected_layer = ProtectedAreas()
 
@@ -77,16 +78,17 @@ class KeyBiodiversityAreaUndeveloped__Percent(Metric):
     MAJOR_NAMING_ATTS = None
     MINOR_NAMING_ATTS = None
 
-    def __init__(self, country_code_iso3=None, **kwargs):
+    def __init__(self, country_code_iso3=None, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.country_code_iso3 = country_code_iso3
+        self.worldpop_version = worldpop_version
 
     def get_metric(self,
                    geo_zone: GeoZone,
                    spatial_resolution: int = None) -> Union[pd.DataFrame, pd.Series]:
         country_code_iso3 = _resolve_country_iso3(geo_zone, self.country_code_iso3)
 
-        worldpop_layer = WorldPop()
+        worldpop_layer = WorldPop(version=self.worldpop_version)
         kba_layer = KeyBiodiversityAreas(country_code_iso3)
         builtup_layer = EsaWorldCover(EsaWorldCoverClass.BUILT_UP)
 

--- a/city_metrix/metrics/recreational_space_per_thousand.py
+++ b/city_metrix/metrics/recreational_space_per_thousand.py
@@ -12,7 +12,7 @@ DEFAULT_SPATIAL_RESOLUTION = 100
 class RecreationalSpacePerThousand__HectaresPerThousandPersons(Metric):
     OUTPUT_FILE_FORMAT = CSV_FILE_EXTENSION
     MAJOR_NAMING_ATTS = None
-    MINOR_NAMING_ATTS = None
+    MINOR_NAMING_ATTS = ["worldpop_version"]
 
     def __init__(self, year=datetime.datetime.now().year, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)

--- a/city_metrix/metrics/recreational_space_per_thousand.py
+++ b/city_metrix/metrics/recreational_space_per_thousand.py
@@ -14,10 +14,11 @@ class RecreationalSpacePerThousand__HectaresPerThousandPersons(Metric):
     MAJOR_NAMING_ATTS = None
     MINOR_NAMING_ATTS = None
 
-    def __init__(self, year=datetime.datetime.now().year, **kwargs):
+    def __init__(self, year=datetime.datetime.now().year, worldpop_version=1, **kwargs):
         super().__init__(**kwargs)
         self.year = year
         self.unit = 'hectares per thousand persons'
+        self.worldpop_version = worldpop_version
 
     def get_metric(self,
                    geo_zone: GeoZone,
@@ -25,7 +26,7 @@ class RecreationalSpacePerThousand__HectaresPerThousandPersons(Metric):
                    ) -> Union[pd.DataFrame | pd.Series]:
         spatial_resolution = DEFAULT_SPATIAL_RESOLUTION if spatial_resolution is None else spatial_resolution
 
-        world_pop = WorldPop()
+        world_pop = WorldPop(version=self.worldpop_version)
         open_space = OpenStreetMap(osm_class=OpenStreetMapClass.OPEN_SPACE)
 
         # per 1000 people


### PR DESCRIPTION
- Create param for version in WorldPop layer
- Add worldpop_version option for all layers and metrics that call on WorldPop
- Add worldpop_version to minor naming apps in WorldPop layer and all calling layers and metrics
- Note: WorldPop in Awesome GEE Community Data stores year as string instead of int: "2020" not 2020
- This branch was originally intended also to add version option for Meta-WRI Tree Canopy Height dataset, but that doesn't seem to be available yet on GEE